### PR TITLE
Fix image name wolstar to wolfstar

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -35,4 +35,4 @@ jobs:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: ghcr.io/wolfstar-project/wolstar.rocks:latest
+          tags: ghcr.io/wolfstar-project/wolfstar.rocks:latest


### PR DESCRIPTION
Fix image name from `wolstar` to `wolfstar` in the Docker image tag due to a typo.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb1e57dc-6b26-435d-8338-5d094855b56b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bb1e57dc-6b26-435d-8338-5d094855b56b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected a typo in the Docker image tag used for continuous delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->