### PR TITLE
fix: add iconify API to connect-src directive

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -414,6 +414,7 @@ export default defineNuxtConfig({
 					"https://cdn.discordapp.com",
 					"https://media.discordapp.net",
 					"https://discord.com",
+					"https://api.iconify.design",
 					"https://*.netlify.com",
 					"https://*.netlify.app",
 					"https://*.wolfstar.rocks",


### PR DESCRIPTION
## What

Add \`https://api.iconify.design\` to the CSP \`connect-src\` directive in \`nuxt.config.ts\`.

## Why

Iconify icons loaded at runtime require fetching SVG data from \`api.iconify.design\`. Without this CSP entry, browsers block the request and icons fail to render.

## Impact

Security configuration change -- adds a single trusted origin to \`connect-src\`.

## Verification

- \`pnpm build\` passes
- Icons render correctly without CSP violations in the browser console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security configuration to enable integration with an external icon library service. This change allows the application to securely load and utilize icons from a trusted endpoint. The updated Content Security Policy settings expand design flexibility and icon availability while maintaining security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->