### PR TITLE
fix(ui): use route name as default og image title

### DIFF
--- a/app/components/OgImage/Page.takumi.vue
+++ b/app/components/OgImage/Page.takumi.vue
@@ -45,7 +45,6 @@
 import type { ResolvableValue } from "@unhead/vue";
 import { useOgImageRuntimeConfig } from "#og-image/app/utils";
 import { useSiteConfig } from "#site-config/app/composables";
-import { computed, defineComponent, h, resolveComponent } from "vue";
 
 export interface OGImageProps {
 	colorMode?: "dark" | "light";
@@ -54,11 +53,12 @@ export interface OGImageProps {
 	icon?: string | boolean;
 	theme?: string;
 }
+const { name } = useRoute();
 
 // Convert to typescript props
 const {
 	theme = BrandingColors.Secondary,
-	title = "title",
+	title = name,
 	colorMode: propsColorMode,
 	description,
 	icon,


### PR DESCRIPTION
## What

- Remove unused Vue import (auto-imported by Nuxt)
- Default the \`title\` prop in \`Page.takumi.vue\` OG image component to the current route name instead of a hardcoded \`"title"\` string

## Why

The OG image was rendering a static "title" text when no title prop was provided. Using the route name provides a meaningful default.

## Impact

Code change (frontend, OG image rendering only).