### PR TITLE
ci: use voidzero-dev/setup-vp instead of setup-node + pnpm/action-setup

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,17 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
-
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # 4e1c8eafbd745f64b1ef30a7d7ed7965034c486c
-        name: 🟧 Install pnpm
-
-      - name: 📦 Install dependencies
-        run: pnpm install
+          cache: true
 
       - name: 🔠 Fix lint errors
-        run: pnpm vp run lint:fix
+        run: vp run lint:fix
 
       - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,18 +28,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # 5e1c8eafbd745f64b1ef30a7d7ed7965034c486c
-        name: 🟧 Install pnpm
+          run-install: false
 
       - name: 📦 Install dependencies (root only, no scripts)
-        run: pnpm install --filter . --ignore-scripts
+        run: vp install --filter . --ignore-scripts
 
       - name: 🔠 Lint project
-        run: pnpm vp run lint
+        run: vp run lint
 
   unit:
     name: 🧪 Unit tests
@@ -48,18 +46,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # 5e1c8eafbd745f64b1ef30a7d7ed7965034c486c
-        name: 🟧 Install pnpm
-
-      - name: 📦 Install dependencies
-        run: pnpm install
+          cache: true
 
       - name: 🧪 Unit tests
-        run: pnpm vp test --project unit --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml
+        run: vp test --project unit --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml
 
       - name: ⬆︎ Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -74,21 +67,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # 5e1c8eafbd745f64b1ef30a7d7ed7965034c486c
-        name: 🟧 Install pnpm
-
-      - name: 📦 Install dependencies
-        run: pnpm install
+          cache: true
 
       - name: 🌐 Install browser
-        run: pnpm vp exec playwright install chromium-headless-shell
+        run: vp exec playwright install chromium-headless-shell
 
       - name: 🧪 Component tests
-        run: pnpm vp test --project nuxt --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml
+        run: vp test --project nuxt --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml
         env:
           NODE_OPTIONS: --max-old-space-size=8192
 
@@ -113,21 +101,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # 5e1c8eafbd745f64b1ef30a7d7ed7965034c486c
-        name: 🟧 Install pnpm
-
-      - name: 📦 Install dependencies
-        run: pnpm install
+          cache: true
 
       - name: 🔼 Generate Prisma Client
-        run: pnpm prisma:generate
+        run: vp run prisma:generate
 
       - name: 🏗️ Build project
-        run: pnpm vp run build:test
+        run: vp run build:test
         env:
           VALIDATE_HTML: true
           NODE_OPTIONS: --max-old-space-size=4096
@@ -135,7 +118,7 @@ jobs:
           NUXT_SESSION_PASSWORD: ci-test-session-password-at-least-32-characters-long
 
       - name: 🖥️ Test project (browser)
-        run: pnpm vp run test:browser:prebuilt
+        run: vp run test:browser:prebuilt
         env:
           NUXT_SESSION_PASSWORD: ci-test-session-password-at-least-32-characters-long
 
@@ -146,21 +129,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # 5e1c8eafbd745f64b1ef30a7d7ed7965034c486c
-        name: 🟧 Install pnpm
-
-      - name: 📦 Install dependencies
-        run: pnpm install
+          cache: true
 
       - name: ⚡ Run benchmarks
         uses: CodSpeedHQ/action@4deb3275dd364fb96fb074c953133d29ec96f80f
         with:
           mode: simulation
-          run: pnpm vp run test:bench
+          run: vp run test:bench
 
   a11y:
     name: ♿ Accessibility audit
@@ -172,27 +150,22 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # 5e1c8eafbd745f64b1ef30a7d7ed7965034c486c
-        name: 🟧 Install pnpm
-
-      - name: 📦 Install dependencies
-        run: pnpm install
+          cache: true
 
       - name: 🔼 Generate Prisma Client
-        run: pnpm prisma:generate
+        run: vp run prisma:generate
 
       - name: 🏗️ Build project
-        run: pnpm vp run build:test
+        run: vp run build:test
         env:
           NUXT_PUBLIC_SITE_URL: https://wolfstar.rocks
           NUXT_SESSION_PASSWORD: ci-test-session-password-at-least-32-characters-long
 
       - name: ♿ Accessibility audit (Lighthouse - ${{ matrix.mode }} mode)
-        run: pnpm vp run test:a11y:prebuilt
+        run: vp run test:a11y:prebuilt
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
           LIGHTHOUSE_COLOR_MODE: ${{ matrix.mode }}
@@ -205,15 +178,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # 5e1c8eafbd745f64b1ef30a7d7ed7965034c486c
-        name: 🟧 Install pnpm
-
-      - name: 📦 Install dependencies
-        run: pnpm install
+          cache: true
 
       - name: 🧹 Check for unused code
-        run: pnpm vp run knip
+        run: vp run knip

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -20,9 +20,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
+          run-install: false
 
       - name: 🔍 Check for unreleased commits
         id: check

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -23,9 +23,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: voidzero-dev/setup-vp@8ecb39174989ce55af90f45cf55b02738599831d # v1.6.0
         with:
           node-version: lts/*
+          run-install: false
 
       - name: 🔢 Determine next version
         id: version
@@ -58,13 +59,9 @@ jobs:
           git tag -a "$VERSION" -m "Release $VERSION"
           git push origin "$VERSION"
 
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
-        if: steps.check.outputs.skip == 'false'
-        name: 🟧 Install pnpm
-
       - name: 📦 Install dependencies
         if: steps.check.outputs.skip == 'false'
-        run: pnpm install --filter . --ignore-scripts
+        run: vp install --filter . --ignore-scripts
 
       - name: 📝 Generate release notes
         if: steps.check.outputs.skip == 'false'


### PR DESCRIPTION
## What

Replace the two-step setup pattern (\`actions/setup-node\` + \`pnpm/action-setup\` + \`pnpm install\`) with the unified \`voidzero-dev/setup-vp\` action across all CI workflows.

## Why

Simplifies CI setup to a single step with \`node-version\`, \`cache\`, and automatic dependency installation via \`vp\`. Based on [npmx-dev/npmx.dev#2145](https://github.com/npmx-dev/npmx.dev/pull/2145).

## Changes

- **continuous-integration.yml**: 7 jobs migrated (lint, unit, test, browser, benchmark, a11y, knip)
- **autofix.yml**: Replaced 3-step setup with single \`setup-vp\`
- **release-tag.yml**: Replaced \`setup-node\` + \`pnpm/action-setup\` with \`setup-vp\`
- **release-pr.yml**: Replaced \`setup-node\` with \`setup-vp\`

### Key patterns

- \`cache: true\` for jobs needing full dependency install (auto-runs \`vp install\`)
- \`run-install: false\` for jobs with partial install (\`vp install --filter . --ignore-scripts\`)
- \`pnpm vp run/test/exec\` -> \`vp run/test/exec\`
- Pinned to \`v1.6.0\` (\`8ecb3917\`)

## Impact

CI-only change. No runtime code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow tooling and infrastructure configurations across automated build and testing pipelines to improve consistency and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->