### PR TITLE
chore: enable sourcemaps in production

### DIFF
--- a/modules/production.ts
+++ b/modules/production.ts
@@ -1,0 +1,20 @@
+import { defu } from "defu";
+import { defineNuxtModule, useNuxt } from "nuxt/kit";
+import { isCI, provider } from "std-env";
+
+export default defineNuxtModule({
+	meta: {
+		name: "prod-env",
+	},
+	setup() {
+		const nuxt = useNuxt();
+
+		if (isCI && provider !== "github_actions") {
+			nuxt.options.debug = defu(nuxt.options.debug, { hydration: true });
+			nuxt.options.sourcemap = {
+				server: true,
+				client: true,
+			};
+		}
+	},
+});

--- a/modules/production.ts
+++ b/modules/production.ts
@@ -1,20 +1,20 @@
 import { defu } from "defu";
-import { defineNuxtModule, useNuxt } from "nuxt/kit";
+import { defineNuxtModule } from "nuxt/kit";
 import { isCI, provider } from "std-env";
 
 export default defineNuxtModule({
 	meta: {
 		name: "prod-env",
 	},
-	setup() {
-		const nuxt = useNuxt();
+	setup(_options, nuxt) {
+		const shouldEnableHydrationDebug = process.env.NUXT_DEBUG_HYDRATION === "true";
 
 		if (isCI && provider !== "github_actions") {
-			nuxt.options.debug = defu(nuxt.options.debug, { hydration: true });
-			nuxt.options.sourcemap = {
-				server: true,
-				client: true,
-			};
+			if (shouldEnableHydrationDebug) {
+				nuxt.options.debug = defu(nuxt.options.debug, { hydration: true });
+			}
+
+			nuxt.options.sourcemap = defu({ server: true }, nuxt.options.sourcemap);
 		}
 	},
 });


### PR DESCRIPTION
- [x] Switch `setup()` to `setup(_options, nuxt)` and drop `useNuxt()` for consistency with other modules
- [x] Make hydration debug opt-in via `NUXT_DEBUG_HYDRATION=true` env var (not always-on in CI)
- [x] Use `defu` to merge sourcemap config, keeping `client: "hidden"` and only enabling `server: true`
- [x] Validated with linter (0 warnings, 0 errors) and typecheck (no errors in production.ts)