### PR TITLE
fix(ui): improve UX copy and accessibility across dashboard

### DIFF
--- a/app/components/guild/card.vue
+++ b/app/components/guild/card.vue
@@ -181,8 +181,8 @@ const cardClasses = computed(() => {
 		"hover:-translate-y-1 hover:shadow-2xl focus-visible:-translate-y-1 focus-visible:shadow-2xl focus-visible:outline-none focus-visible:ring-2 motion-reduce:hover:shadow-xl motion-reduce:hover:translate-y-0": true,
 		"hover:border-primary/40 focus-visible:border-primary/50 focus-visible:ring-primary/40":
 			!guild.wolfstarIsIn && guild.manageable,
-		"opacity-75 ring-2 ring-error/20": !guild.manageable,
-		"ring-2 ring-success/20 hover:border-success/40 focus-visible:border-success/50 focus-visible:ring-success/40":
+		"opacity-75 outline outline-2 outline-error/20": !guild.manageable,
+		"outline outline-2 outline-success/20 hover:border-success/40 focus-visible:border-success/50 focus-visible:ring-success/40":
 			guild.wolfstarIsIn && guild.manageable,
 	};
 });

--- a/app/components/guild/card.vue
+++ b/app/components/guild/card.vue
@@ -102,28 +102,22 @@
 
 				<!-- Guild Stats -->
 				<div class="flex items-center justify-center gap-4 text-xs text-base-content/60">
-					<span
-						class="flex items-center gap-1"
-						title="Total members"
-						aria-label="Total members"
-					>
+					<span class="flex items-center gap-1" title="Total members">
 						<UIcon
 							name="heroicons:user-group"
 							class="size-3 text-base-content/70"
 							aria-hidden="true"
 						/>
+						<span class="sr-only">Total members:</span>
 						<span>{{ approximateMemberCount }}</span>
 					</span>
-					<span
-						class="flex items-center gap-1"
-						title="Members online"
-						aria-label="Members online"
-					>
+					<span class="flex items-center gap-1" title="Members online">
 						<UIcon
 							name="heroicons:signal"
 							class="size-3 text-success"
 							aria-hidden="true"
 						/>
+						<span class="sr-only">Members online:</span>
 						<span>{{ approximatePresenceCount }}</span>
 					</span>
 				</div>
@@ -159,7 +153,7 @@
 					<div
 						v-else
 						class="flex h-9 w-full cursor-not-allowed items-center justify-center rounded-lg bg-base-300/50 px-3 text-xs font-medium text-base-content/50 transition-all duration-200"
-						role="status"
+						role="note"
 						:aria-label="`No permission to manage ${guild.name}`"
 					>
 						<UIcon

--- a/app/components/guild/card.vue
+++ b/app/components/guild/card.vue
@@ -149,8 +149,6 @@
 					<div
 						v-else
 						class="flex h-9 w-full cursor-not-allowed items-center justify-center rounded-lg bg-base-300/50 px-3 text-xs font-medium text-base-content/50 transition-all duration-200"
-						role="note"
-						:aria-label="`No permission to manage ${guild.name}`"
 					>
 						<UIcon
 							name="heroicons:no-symbol"

--- a/app/components/guild/card.vue
+++ b/app/components/guild/card.vue
@@ -81,18 +81,24 @@
 					<guild-icon :guild variant="bare" size="lg" :show-status="true" />
 				</div>
 				<!-- Guild Name -->
-				<span class="w-full truncate text-center text-xs font-medium text-base-content">
+				<span
+					class="w-full truncate text-center text-xs font-medium"
+					:class="guild.manageable ? 'text-base-content' : 'text-base-content/50'"
+				>
 					{{ guild.name }}
 				</span>
 			</div>
 
 			<!-- Desktop: Vertical layout (original) -->
 			<div class="hidden h-full w-full flex-col items-center gap-3 text-center md:flex">
-				<div class="flex flex-col items-center">
+				<div class="flex flex-col items-center" :class="{ 'opacity-60': !guild.manageable }">
 					<guild-icon :guild variant="bare" size="lg" :show-status="true" />
 				</div>
 				<!-- Guild Name -->
-				<h3 class="line-clamp-2 min-h-12 text-base font-bold text-base-content">
+				<h3
+					class="line-clamp-2 min-h-12 text-base font-bold"
+					:class="guild.manageable ? 'text-base-content' : 'text-base-content/50'"
+				>
 					{{ guild.name }}
 				</h3>
 
@@ -181,7 +187,7 @@ const cardClasses = computed(() => {
 		"hover:-translate-y-1 hover:shadow-2xl focus-visible:-translate-y-1 focus-visible:shadow-2xl focus-visible:outline-none focus-visible:ring-2 motion-reduce:hover:shadow-xl motion-reduce:hover:translate-y-0": true,
 		"hover:border-primary/40 focus-visible:border-primary/50 focus-visible:ring-primary/40":
 			!guild.wolfstarIsIn && guild.manageable,
-		"opacity-75 outline outline-2 outline-error/20": !guild.manageable,
+		"outline outline-2 outline-error/20": !guild.manageable,
 		"outline outline-2 outline-success/20 hover:border-success/40 focus-visible:border-success/50 focus-visible:ring-success/40":
 			guild.wolfstarIsIn && guild.manageable,
 	};

--- a/app/components/guild/card.vue
+++ b/app/components/guild/card.vue
@@ -88,11 +88,7 @@
 
 			<!-- Desktop: Vertical layout (original) -->
 			<div class="hidden h-full w-full flex-col items-center gap-3 text-center md:flex">
-				<div
-					class="flex flex-col items-center"
-					role="img"
-					:aria-label="`${guild.name} server icon`"
-				>
+				<div class="flex flex-col items-center">
 					<guild-icon :guild variant="bare" size="lg" :show-status="true" />
 				</div>
 				<!-- Guild Name -->

--- a/app/components/guild/cards.vue
+++ b/app/components/guild/cards.vue
@@ -51,7 +51,7 @@
 					<guild-card
 						v-for="guild in paginatedGuilds"
 						:key="guild.id"
-						v-memo="[guild.id, guild.name, guild.manageable]"
+						v-memo="[guild.id, guild.name, guild.manageable, guild.wolfstarIsIn]"
 						:guild
 						role="listitem"
 					/>

--- a/app/components/guild/cards.vue
+++ b/app/components/guild/cards.vue
@@ -46,7 +46,7 @@
 					tag="div"
 					class="grid grid-cols-2 gap-8 sm:grid-cols-3 md:grid-cols-3 md:gap-6 lg:grid-cols-4 xl:grid-cols-5"
 					role="list"
-					aria-label="Guilds list"
+					aria-label="Servers list"
 				>
 					<guild-card
 						v-for="guild in paginatedGuilds"

--- a/app/components/guild/settings/Channels.vue
+++ b/app/components/guild/settings/Channels.vue
@@ -39,7 +39,7 @@
 			<div class="space-y-4">
 				<div class="flex items-center gap-2">
 					<UIcon name="heroicons:eye-slash" class="size-5 text-warning" />
-					<h3 class="text-lg font-semibold text-base-content">Ignore Channels</h3>
+					<h3 class="text-lg font-semibold text-base-content">Excluded Channels</h3>
 				</div>
 				<p class="text-sm text-base-content/70">
 					Select channels that should be ignored for specific logging events. Messages and
@@ -114,7 +114,7 @@ async function onError(event: FormErrorEvent) {
 	const errorMessage = event.errors[0]?.message;
 	toast.add({
 		color: "error",
-		description: `Could not save channel settings. ${errorMessage ?? "Please try again."}`,
+		description: `Couldn't save channel settings. ${errorMessage ?? "Please try again."}`,
 		icon: "heroicons:x-circle",
 		title: "Save Failed",
 	});

--- a/app/components/guild/settings/Channels.vue
+++ b/app/components/guild/settings/Channels.vue
@@ -7,7 +7,7 @@
 			:state="state"
 			:schema="schema"
 			:map-to-guild-data="mapToGuildData"
-			aria-label="General guild settings form"
+			aria-label="Channel settings form"
 			class="space-y-8"
 			@error="onError"
 		>

--- a/app/components/guild/settings/Events.vue
+++ b/app/components/guild/settings/Events.vue
@@ -116,7 +116,7 @@ async function onError(event: FormErrorEvent) {
 	const errorMessage = event.errors[0]?.message;
 	toast.add({
 		color: "error",
-		description: `Could not save event settings. ${errorMessage ?? "Please try again."}`,
+		description: `Couldn't save event settings. ${errorMessage ?? "Please try again."}`,
 		icon: "heroicons:x-circle",
 		title: "Save Failed",
 	});

--- a/app/components/guild/settings/General.vue
+++ b/app/components/guild/settings/General.vue
@@ -57,7 +57,7 @@
 					<UInput
 						id="prefix"
 						v-model="state.prefix"
-						placeholder="Enter prefix"
+						placeholder="!"
 						color="primary"
 						class="w-full"
 						aria-describedby="prefix-description character-count"
@@ -79,7 +79,7 @@
 					</template>
 					<template #description>
 						<p id="prefix-description" class="text-sm text-base-content/70">
-							This is your server's prefix, use it to trigger WolfStar commands.
+							The prefix used to trigger WolfStar commands in this server.
 						</p>
 					</template>
 				</UFormField>
@@ -89,7 +89,7 @@
 				<UFormField label="Language" name="language">
 					<template #description>
 						<p id="language-description" class="text-sm text-base-content/70">
-							Select the language you want for this guild
+							The language WolfStar uses for responses in this server.
 						</p>
 					</template>
 					<USelectMenu
@@ -237,7 +237,7 @@ async function onError(event: FormErrorEvent) {
 	const errorMessage = event.errors[0]?.message;
 	toast.add({
 		color: "error",
-		description: `Could not save general settings. ${errorMessage ?? "Please try again."}`,
+		description: `Couldn't save general settings. ${errorMessage ?? "Please try again."}`,
 		icon: "heroicons:x-circle",
 		title: "Save Failed",
 	});

--- a/app/components/guild/settings/Moderation.vue
+++ b/app/components/guild/settings/Moderation.vue
@@ -62,7 +62,7 @@ async function onError(event: FormErrorEvent) {
 	const errorMessage = event.errors[0]?.message;
 	toast.add({
 		color: "error",
-		description: `Could not save moderation settings. ${errorMessage ?? "Please try again."}`,
+		description: `Couldn't save moderation settings. ${errorMessage ?? "Please try again."}`,
 		icon: "heroicons:x-circle",
 		title: "Save Failed",
 	});

--- a/app/components/guild/settings/Roles.vue
+++ b/app/components/guild/settings/Roles.vue
@@ -1,7 +1,7 @@
 <template>
 	<GuildSettingsSection
 		title="Roles"
-		subtitle="Configure special roles that WolfStar uses on your server."
+		subtitle="Configure the roles WolfStar uses for moderation, permissions, and automation."
 	>
 		<!-- Loading Skeleton -->
 		<div v-if="loading" class="space-y-8">
@@ -60,7 +60,7 @@
 					<h3 class="text-lg font-semibold text-base-content">Configurable Roles</h3>
 				</div>
 				<p class="text-sm text-base-content/70">
-					Assign specific roles for different bot functions and permissions.
+					Assign roles for core bot functions like moderation and auto-assignment.
 				</p>
 
 				<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -95,7 +95,7 @@
 					<h3 class="text-lg font-semibold text-base-content">Restricted Roles</h3>
 				</div>
 				<p class="text-sm text-base-content/70">
-					Roles used for restricted moderation commands.
+					Roles applied when a restriction command is used.
 				</p>
 
 				<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/app/components/guild/settings/filter/Capitals.vue
+++ b/app/components/guild/settings/filter/Capitals.vue
@@ -54,7 +54,7 @@
 									{{ state.selfmodCapitalsEnabled ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Whether or not this system should be enabled.
+									Flags messages with excessive capital letters.
 								</p>
 							</div>
 						</div>
@@ -72,7 +72,7 @@
 									Alerts {{ state.softActionAlerts ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message alerts in the channel the infraction took place.
+									Posts an alert in the channel where the violation occurred.
 								</p>
 							</div>
 						</div>
@@ -90,7 +90,7 @@
 									Logs {{ state.softActionLogs ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message logs in the moderation logs channel.
+									Sends a log entry to the moderation logs channel.
 								</p>
 							</div>
 						</div>
@@ -107,7 +107,9 @@
 								<p class="text-sm leading-none font-medium">
 									Deletes {{ state.softActionDeletes ? "Enabled" : "Disabled" }}
 								</p>
-								<p class="mt-1 text-xs text-muted">Toggle message deletions.</p>
+								<p class="mt-1 text-xs text-muted">
+									Automatically deletes the offending message.
+								</p>
 							</div>
 						</div>
 					</UFormField>
@@ -122,7 +124,7 @@
 					<UFormField
 						label="Action"
 						name="selfmodCapitalsHardAction"
-						description="The action to perform as punishment"
+						description="What happens when a member exceeds the limit"
 					>
 						<USelectMenu
 							v-model="selectedHardAction"
@@ -135,7 +137,7 @@
 					<UFormField
 						label="Duration"
 						name="hardActionDurationMs"
-						description="How long the punishment should last"
+						description="How long the mute or ban lasts"
 					>
 						<SelectDuration
 							v-model="state.hardActionDurationMs"
@@ -148,7 +150,7 @@
 				<div class="mt-4 space-y-5">
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Maximum Threshold
+							Violations before punishment
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodCapitalsThresholdMaximum }})</span
 							>
@@ -157,7 +159,7 @@
 							v-model="state.selfmodCapitalsThresholdMaximum"
 							:min="0"
 							:max="60"
-							aria-label="Capitals selfmod filter maximum threshold slider"
+							aria-label="Capitals filter violations before punishment slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0</span>
@@ -167,7 +169,7 @@
 
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Threshold Duration (in seconds)
+							Time window (seconds)
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodCapitalsThresholdDurationSeconds }}s)</span
 							>
@@ -176,7 +178,7 @@
 							v-model="state.selfmodCapitalsThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="Capitals selfmod filter threshold duration slider"
+							aria-label="Capitals filter time window slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>
@@ -332,7 +334,7 @@ async function onError(event: FormErrorEvent) {
 	const errorMessage = event.errors[0]?.message;
 	toast.add({
 		color: "error",
-		description: `Could not save capitals filter settings. ${errorMessage ?? "Please try again."}`,
+		description: `Couldn't save capitals filter settings. ${errorMessage ?? "Please try again."}`,
 		icon: "heroicons:x-circle",
 		title: "Save Failed",
 	});

--- a/app/components/guild/settings/filter/Capitals.vue
+++ b/app/components/guild/settings/filter/Capitals.vue
@@ -178,7 +178,7 @@
 							v-model="state.selfmodCapitalsThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="Capitals filter time window slider"
+							aria-label="Capitals filter time window (seconds) slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>

--- a/app/components/guild/settings/filter/Invites.vue
+++ b/app/components/guild/settings/filter/Invites.vue
@@ -173,7 +173,7 @@
 							v-model="state.selfmodInvitesThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="Invites filter time window slider"
+							aria-label="Invites filter time window (seconds) slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>

--- a/app/components/guild/settings/filter/Invites.vue
+++ b/app/components/guild/settings/filter/Invites.vue
@@ -49,7 +49,7 @@
 									{{ state.selfmodInvitesEnabled ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Whether or not this system should be enabled.
+									Detects and removes Discord invite links.
 								</p>
 							</div>
 						</div>
@@ -67,7 +67,7 @@
 									Alerts {{ state.softActionAlerts ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message alerts in the channel the infraction took place.
+									Posts an alert in the channel where the violation occurred.
 								</p>
 							</div>
 						</div>
@@ -85,7 +85,7 @@
 									Logs {{ state.softActionLogs ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message logs in the moderation logs channel.
+									Sends a log entry to the moderation logs channel.
 								</p>
 							</div>
 						</div>
@@ -102,7 +102,9 @@
 								<p class="text-sm leading-none font-medium">
 									Deletes {{ state.softActionDeletes ? "Enabled" : "Disabled" }}
 								</p>
-								<p class="mt-1 text-xs text-muted">Toggle message deletions.</p>
+								<p class="mt-1 text-xs text-muted">
+									Automatically deletes the offending message.
+								</p>
 							</div>
 						</div>
 					</UFormField>
@@ -117,7 +119,7 @@
 					<UFormField
 						label="Action"
 						name="selfmodInvitesHardAction"
-						description="The action to perform as punishment"
+						description="What happens when a member exceeds the limit"
 					>
 						<USelectMenu
 							v-model="selectedHardAction"
@@ -130,7 +132,7 @@
 					<UFormField
 						label="Duration"
 						name="hardActionDurationMs"
-						description="How long the punishment should last"
+						description="How long the mute or ban lasts"
 					>
 						<SelectDuration
 							v-model="state.hardActionDurationMs"
@@ -143,7 +145,7 @@
 				<div class="mt-4 space-y-5">
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Maximum Threshold
+							Violations before punishment
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodInvitesThresholdMaximum }})</span
 							>
@@ -152,7 +154,7 @@
 							v-model="state.selfmodInvitesThresholdMaximum"
 							:min="0"
 							:max="60"
-							aria-label="Invites selfmod filter maximum threshold slider"
+							aria-label="Invites filter violations before punishment slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0</span>
@@ -162,7 +164,7 @@
 
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Threshold Duration (in seconds)
+							Time window (seconds)
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodInvitesThresholdDurationSeconds }}s)</span
 							>
@@ -171,7 +173,7 @@
 							v-model="state.selfmodInvitesThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="Invites selfmod filter threshold duration slider"
+							aria-label="Invites filter time window slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>
@@ -278,7 +280,7 @@ async function onError(event: FormErrorEvent) {
 	const errorMessage = event.errors[0]?.message;
 	toast.add({
 		color: "error",
-		description: `Could not save invite filter settings. ${errorMessage ?? "Please try again."}`,
+		description: `Couldn't save invite filter settings. ${errorMessage ?? "Please try again."}`,
 		icon: "heroicons:x-circle",
 		title: "Save Failed",
 	});

--- a/app/components/guild/settings/filter/Links.vue
+++ b/app/components/guild/settings/filter/Links.vue
@@ -179,7 +179,7 @@
 							v-model="state.selfmodLinksThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="Links filter time window slider"
+							aria-label="Links filter time window (seconds) slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>

--- a/app/components/guild/settings/filter/Links.vue
+++ b/app/components/guild/settings/filter/Links.vue
@@ -55,7 +55,7 @@
 									Filter {{ state.selfmodLinksEnabled ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Whether or not this system should be enabled.
+									Detects and removes external links.
 								</p>
 							</div>
 						</div>
@@ -73,7 +73,7 @@
 									Alerts {{ state.softActionAlerts ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message alerts in the channel the infraction took place.
+									Posts an alert in the channel where the violation occurred.
 								</p>
 							</div>
 						</div>
@@ -91,7 +91,7 @@
 									Logs {{ state.softActionLogs ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message logs in the moderation logs channel.
+									Sends a log entry to the moderation logs channel.
 								</p>
 							</div>
 						</div>
@@ -108,7 +108,9 @@
 								<p class="text-sm leading-none font-medium">
 									Deletes {{ state.softActionDeletes ? "Enabled" : "Disabled" }}
 								</p>
-								<p class="mt-1 text-xs text-muted">Toggle message deletions.</p>
+								<p class="mt-1 text-xs text-muted">
+									Automatically deletes the offending message.
+								</p>
 							</div>
 						</div>
 					</UFormField>
@@ -123,7 +125,7 @@
 					<UFormField
 						label="Action"
 						name="selfmodLinksHardAction"
-						description="The action to perform as punishment"
+						description="What happens when a member exceeds the limit"
 					>
 						<USelectMenu
 							v-model="selectedHardAction"
@@ -136,7 +138,7 @@
 					<UFormField
 						label="Duration"
 						name="hardActionDurationMs"
-						description="How long the punishment should last"
+						description="How long the mute or ban lasts"
 					>
 						<SelectDuration
 							v-model="state.hardActionDurationMs"
@@ -149,7 +151,7 @@
 				<div class="mt-4 space-y-5">
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Maximum Threshold
+							Violations before punishment
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodLinksThresholdMaximum }})</span
 							>
@@ -158,7 +160,7 @@
 							v-model="state.selfmodLinksThresholdMaximum"
 							:min="0"
 							:max="60"
-							aria-label="Links selfmod filter maximum threshold slider"
+							aria-label="Links filter violations before punishment slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0</span>
@@ -168,7 +170,7 @@
 
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Threshold Duration (in seconds)
+							Time window (seconds)
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodLinksThresholdDurationSeconds }}s)</span
 							>
@@ -177,7 +179,7 @@
 							v-model="state.selfmodLinksThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="Links selfmod filter threshold duration slider"
+							aria-label="Links filter time window slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>
@@ -350,7 +352,7 @@ async function onError(event: FormErrorEvent) {
 	const errorMessage = event.errors[0]?.message;
 	toast.add({
 		color: "error",
-		description: `Could not save link filter settings. ${errorMessage ?? "Please try again."}`,
+		description: `Couldn't save link filter settings. ${errorMessage ?? "Please try again."}`,
 		icon: "heroicons:x-circle",
 		title: "Save Failed",
 	});

--- a/app/components/guild/settings/filter/MessageDuplication.vue
+++ b/app/components/guild/settings/filter/MessageDuplication.vue
@@ -173,7 +173,7 @@
 							v-model="state.selfmodMessagesThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="Messages filter time window slider"
+							aria-label="Messages filter time window (seconds) slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>

--- a/app/components/guild/settings/filter/MessageDuplication.vue
+++ b/app/components/guild/settings/filter/MessageDuplication.vue
@@ -49,7 +49,7 @@
 									{{ state.selfmodMessagesEnabled ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Whether or not this system should be enabled.
+									Detects repeated or copy-pasted messages.
 								</p>
 							</div>
 						</div>
@@ -67,7 +67,7 @@
 									Alerts {{ state.softActionAlerts ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message alerts in the channel the infraction took place.
+									Posts an alert in the channel where the violation occurred.
 								</p>
 							</div>
 						</div>
@@ -85,7 +85,7 @@
 									Logs {{ state.softActionLogs ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message logs in the moderation logs channel.
+									Sends a log entry to the moderation logs channel.
 								</p>
 							</div>
 						</div>
@@ -102,7 +102,9 @@
 								<p class="text-sm leading-none font-medium">
 									Deletes {{ state.softActionDeletes ? "Enabled" : "Disabled" }}
 								</p>
-								<p class="mt-1 text-xs text-muted">Toggle message deletions.</p>
+								<p class="mt-1 text-xs text-muted">
+									Automatically deletes the offending message.
+								</p>
 							</div>
 						</div>
 					</UFormField>
@@ -117,7 +119,7 @@
 					<UFormField
 						label="Action"
 						name="selfmodMessagesHardAction"
-						description="The action to perform as punishment"
+						description="What happens when a member exceeds the limit"
 					>
 						<USelectMenu
 							v-model="selectedHardAction"
@@ -130,7 +132,7 @@
 					<UFormField
 						label="Duration"
 						name="hardActionDurationMs"
-						description="How long the punishment should last"
+						description="How long the mute or ban lasts"
 					>
 						<SelectDuration
 							v-model="state.hardActionDurationMs"
@@ -143,7 +145,7 @@
 				<div class="mt-4 space-y-5">
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Maximum Threshold
+							Violations before punishment
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodMessagesThresholdMaximum }})</span
 							>
@@ -152,7 +154,7 @@
 							v-model="state.selfmodMessagesThresholdMaximum"
 							:min="0"
 							:max="60"
-							aria-label="Messages selfmod filter maximum threshold slider"
+							aria-label="Messages filter violations before punishment slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0</span>
@@ -162,7 +164,7 @@
 
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Threshold Duration (in seconds)
+							Time window (seconds)
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodMessagesThresholdDurationSeconds }}s)</span
 							>
@@ -171,7 +173,7 @@
 							v-model="state.selfmodMessagesThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="Messages selfmod filter threshold duration slider"
+							aria-label="Messages filter time window slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>
@@ -278,7 +280,7 @@ async function onError(event: FormErrorEvent) {
 	const errorMessage = event.errors[0]?.message;
 	toast.add({
 		color: "error",
-		description: `Could not save message duplication filter settings. ${errorMessage ?? "Please try again."}`,
+		description: `Couldn't save message duplication filter settings. ${errorMessage ?? "Please try again."}`,
 		icon: "heroicons:x-circle",
 		title: "Save Failed",
 	});

--- a/app/components/guild/settings/filter/NewLine.vue
+++ b/app/components/guild/settings/filter/NewLine.vue
@@ -53,7 +53,7 @@
 									{{ state.selfmodNewlinesEnabled ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Whether or not this system should be enabled.
+									Flags messages with excessive line breaks.
 								</p>
 							</div>
 						</div>
@@ -71,7 +71,7 @@
 									Alerts {{ state.softActionAlerts ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message alerts in the channel the infraction took place.
+									Posts an alert in the channel where the violation occurred.
 								</p>
 							</div>
 						</div>
@@ -89,7 +89,7 @@
 									Logs {{ state.softActionLogs ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message logs in the moderation logs channel.
+									Sends a log entry to the moderation logs channel.
 								</p>
 							</div>
 						</div>
@@ -106,7 +106,9 @@
 								<p class="text-sm leading-none font-medium">
 									Deletes {{ state.softActionDeletes ? "Enabled" : "Disabled" }}
 								</p>
-								<p class="mt-1 text-xs text-muted">Toggle message deletions.</p>
+								<p class="mt-1 text-xs text-muted">
+									Automatically deletes the offending message.
+								</p>
 							</div>
 						</div>
 					</UFormField>
@@ -121,7 +123,7 @@
 					<UFormField
 						label="Action"
 						name="selfmodNewlinesHardAction"
-						description="The action to perform as punishment"
+						description="What happens when a member exceeds the limit"
 					>
 						<USelectMenu
 							v-model="selectedHardAction"
@@ -134,7 +136,7 @@
 					<UFormField
 						label="Duration"
 						name="hardActionDurationMs"
-						description="How long the punishment should last"
+						description="How long the mute or ban lasts"
 					>
 						<SelectDuration
 							v-model="state.hardActionDurationMs"
@@ -147,7 +149,7 @@
 				<div class="mt-4 space-y-5">
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Maximum Threshold
+							Violations before punishment
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodNewlinesThresholdMaximum }})</span
 							>
@@ -156,7 +158,7 @@
 							v-model="state.selfmodNewlinesThresholdMaximum"
 							:min="0"
 							:max="60"
-							aria-label="New lines selfmod filter maximum threshold slider"
+							aria-label="New lines filter violations before punishment slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0</span>
@@ -166,7 +168,7 @@
 
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Threshold Duration (in seconds)
+							Time window (seconds)
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodNewlinesThresholdDurationSeconds }}s)</span
 							>
@@ -175,7 +177,7 @@
 							v-model="state.selfmodNewlinesThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="New lines selfmod filter threshold duration slider"
+							aria-label="New lines filter time window slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>
@@ -311,7 +313,7 @@ async function onError(event: FormErrorEvent) {
 	const errorMessage = event.errors[0]?.message;
 	toast.add({
 		color: "error",
-		description: `Could not save line spam filter settings. ${errorMessage ?? "Please try again."}`,
+		description: `Couldn't save line spam filter settings. ${errorMessage ?? "Please try again."}`,
 		icon: "heroicons:x-circle",
 		title: "Save Failed",
 	});

--- a/app/components/guild/settings/filter/NewLine.vue
+++ b/app/components/guild/settings/filter/NewLine.vue
@@ -177,7 +177,7 @@
 							v-model="state.selfmodNewlinesThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="New lines filter time window slider"
+							aria-label="New lines filter time window (seconds) slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>

--- a/app/components/guild/settings/filter/Reactions.vue
+++ b/app/components/guild/settings/filter/Reactions.vue
@@ -173,7 +173,7 @@
 							v-model="state.selfmodReactionsThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="Reactions filter time window slider"
+							aria-label="Reactions filter time window (seconds) slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>

--- a/app/components/guild/settings/filter/Reactions.vue
+++ b/app/components/guild/settings/filter/Reactions.vue
@@ -49,7 +49,7 @@
 									{{ state.selfmodReactionsEnabled ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Whether or not this system should be enabled.
+									Limits how many reactions a member can add.
 								</p>
 							</div>
 						</div>
@@ -67,7 +67,7 @@
 									Alerts {{ state.softActionAlerts ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message alerts in the channel the infraction took place.
+									Posts an alert in the channel where the violation occurred.
 								</p>
 							</div>
 						</div>
@@ -85,7 +85,7 @@
 									Logs {{ state.softActionLogs ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message logs in the moderation logs channel.
+									Sends a log entry to the moderation logs channel.
 								</p>
 							</div>
 						</div>
@@ -102,7 +102,9 @@
 								<p class="text-sm leading-none font-medium">
 									Deletes {{ state.softActionDeletes ? "Enabled" : "Disabled" }}
 								</p>
-								<p class="mt-1 text-xs text-muted">Toggle message deletions.</p>
+								<p class="mt-1 text-xs text-muted">
+									Automatically deletes the offending message.
+								</p>
 							</div>
 						</div>
 					</UFormField>
@@ -117,7 +119,7 @@
 					<UFormField
 						label="Action"
 						name="selfmodReactionsHardAction"
-						description="The action to perform as punishment"
+						description="What happens when a member exceeds the limit"
 					>
 						<USelectMenu
 							v-model="selectedHardAction"
@@ -130,7 +132,7 @@
 					<UFormField
 						label="Duration"
 						name="hardActionDurationMs"
-						description="How long the punishment should last"
+						description="How long the mute or ban lasts"
 					>
 						<SelectDuration
 							v-model="state.hardActionDurationMs"
@@ -143,7 +145,7 @@
 				<div class="mt-4 space-y-5">
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Maximum Threshold
+							Violations before punishment
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodReactionsThresholdMaximum }})</span
 							>
@@ -152,7 +154,7 @@
 							v-model="state.selfmodReactionsThresholdMaximum"
 							:min="0"
 							:max="60"
-							aria-label="Reactions selfmod filter maximum threshold slider"
+							aria-label="Reactions filter violations before punishment slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0</span>
@@ -162,7 +164,7 @@
 
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Threshold Duration (in seconds)
+							Time window (seconds)
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodReactionsThresholdDurationSeconds }}s)</span
 							>
@@ -171,7 +173,7 @@
 							v-model="state.selfmodReactionsThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="Reactions selfmod filter threshold duration slider"
+							aria-label="Reactions filter time window slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>
@@ -279,7 +281,7 @@ async function onError(event: FormErrorEvent) {
 	const errorMessage = event.errors[0]?.message;
 	toast.add({
 		color: "error",
-		description: `Could not save reaction filter settings. ${errorMessage ?? "Please try again."}`,
+		description: `Couldn't save reaction filter settings. ${errorMessage ?? "Please try again."}`,
 		icon: "heroicons:x-circle",
 		title: "Save Failed",
 	});

--- a/app/components/guild/settings/filter/Word.vue
+++ b/app/components/guild/settings/filter/Word.vue
@@ -124,7 +124,7 @@
 				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 					<UFormField
 						label="Action"
-						name="selfmodCapitalsHardAction"
+						name="selfmodFilterHardAction"
 						description="What happens when a member exceeds the limit"
 					>
 						<USelectMenu

--- a/app/components/guild/settings/filter/Word.vue
+++ b/app/components/guild/settings/filter/Word.vue
@@ -179,7 +179,7 @@
 							v-model="state.selfmodFilterThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="Word filter time window slider"
+							aria-label="Word filter time window (seconds) slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>

--- a/app/components/guild/settings/filter/Word.vue
+++ b/app/components/guild/settings/filter/Word.vue
@@ -55,7 +55,7 @@
 									Filter {{ state.selfmodFilterEnabled ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Whether or not this system should be enabled.
+									Blocks messages containing specific words or phrases.
 								</p>
 							</div>
 						</div>
@@ -73,7 +73,7 @@
 									Alerts {{ state.softActionAlerts ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message alerts in the channel the infraction took place.
+									Posts an alert in the channel where the violation occurred.
 								</p>
 							</div>
 						</div>
@@ -91,7 +91,7 @@
 									Logs {{ state.softActionLogs ? "Enabled" : "Disabled" }}
 								</p>
 								<p class="mt-1 text-xs text-muted">
-									Toggle message logs in the moderation logs channel.
+									Sends a log entry to the moderation logs channel.
 								</p>
 							</div>
 						</div>
@@ -108,7 +108,9 @@
 								<p class="text-sm leading-none font-medium">
 									Deletes {{ state.softActionDeletes ? "Enabled" : "Disabled" }}
 								</p>
-								<p class="mt-1 text-xs text-muted">Toggle message deletions.</p>
+								<p class="mt-1 text-xs text-muted">
+									Automatically deletes the offending message.
+								</p>
 							</div>
 						</div>
 					</UFormField>
@@ -123,7 +125,7 @@
 					<UFormField
 						label="Action"
 						name="selfmodCapitalsHardAction"
-						description="The action to perform as punishment"
+						description="What happens when a member exceeds the limit"
 					>
 						<USelectMenu
 							v-model="selectedHardAction"
@@ -136,7 +138,7 @@
 					<UFormField
 						label="Duration"
 						name="hardActionDurationMs"
-						description="How long the punishment should last"
+						description="How long the mute or ban lasts"
 					>
 						<SelectDuration
 							v-model="state.hardActionDurationMs"
@@ -149,7 +151,7 @@
 				<div class="mt-4 space-y-5">
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Maximum Threshold
+							Violations before punishment
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodFilterThresholdMaximum }})</span
 							>
@@ -158,7 +160,7 @@
 							v-model="state.selfmodFilterThresholdMaximum"
 							:min="0"
 							:max="60"
-							aria-label="Words selfmod filter maximum threshold slider"
+							aria-label="Words filter violations before punishment slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0</span>
@@ -168,7 +170,7 @@
 
 					<div>
 						<p class="mb-2 text-sm font-medium">
-							Threshold Duration (in seconds)
+							Time window (seconds)
 							<span class="ml-1 text-muted tabular-nums"
 								>({{ state.selfmodFilterThresholdDurationSeconds }}s)</span
 							>
@@ -177,7 +179,7 @@
 							v-model="state.selfmodFilterThresholdDurationSeconds"
 							:min="0"
 							:max="120"
-							aria-label="Word selfmod filter threshold duration slider"
+							aria-label="Word filter time window slider"
 						/>
 						<div class="mt-1 flex justify-between text-xs text-muted">
 							<span>0s</span>
@@ -345,7 +347,7 @@ async function onError(event: FormErrorEvent) {
 	const errorMessage = event.errors[0]?.message;
 	toast.add({
 		color: "error",
-		description: `Could not save word filter settings. ${errorMessage ?? "Please try again."}`,
+		description: `Couldn't save word filter settings. ${errorMessage ?? "Please try again."}`,
 		icon: "heroicons:x-circle",
 		title: "Save Failed",
 	});

--- a/app/components/select/Duration.vue
+++ b/app/components/select/Duration.vue
@@ -5,7 +5,7 @@
 				<UInput
 					v-model="durationString"
 					type="tel"
-					placeholder="Duration"
+					placeholder="10"
 					:color="error ? 'error' : 'primary'"
 					@input="onChangeDuration"
 				/>

--- a/app/components/select/Role.vue
+++ b/app/components/select/Role.vue
@@ -23,9 +23,9 @@ import type { SelectOneValue } from "./One.vue";
 interface SelectRoleProps {
 	/** The label to show on the button */
 	label: string;
-	/** The current selected channel ID */
+	/** The current selected role ID */
 	modelValue: string | null;
-	/** The guild data containing channels */
+	/** The guild data containing roles */
 	guild: DeepReadonly<ValuesType<NonNullable<TransformedLoginData["transformedGuilds"]>>>;
 	/** Content to be shown as a tooltip when hovering over the button */
 	tooltipTitle?: string;
@@ -54,7 +54,7 @@ const {
 
 defineEmits<Emits>();
 
-// Find the channel name based on the current value
+// Find the role name based on the current value
 const roleName = computed(() => {
 	if (!modelValue) {
 		return undefined;
@@ -63,7 +63,7 @@ const roleName = computed(() => {
 	return role?.name;
 });
 
-// Filter and sort channels, then map to SelectOneValue format
+// Filter and sort roles, then map to SelectOneValue format
 const roleValues = computed<SelectOneValue[]>(() =>
 	[...guild.roles]
 		.toSorted((c1, c2) => c1.rawPosition - c2.rawPosition)

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,8 +1,14 @@
 <template>
 	<div class="app-layout" :class="appName">
+		<a
+			href="#maincontent"
+			class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-100 focus:rounded-lg focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-content focus:shadow-lg"
+		>
+			Skip to main content
+		</a>
 		<AppHeader />
 
-		<UMain aria-label="Main content">
+		<UMain id="maincontent" tabindex="-1" aria-label="Main content">
 			<slot></slot>
 		</UMain>
 

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -2,7 +2,7 @@
 	<div class="app-layout" :class="appName">
 		<a
 			href="#maincontent"
-			class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-100 focus:rounded-lg focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-content focus:shadow-lg"
+			class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:rounded-lg focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-content focus:shadow-lg"
 		>
 			Skip to main content
 		</a>

--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -4,6 +4,7 @@
 		<h1 class="sr-only">User Profile</h1>
 		<section
 			class="relative flex flex-col items-center justify-center gap-6 overflow-hidden rounded-xl border-2 border-base-200 bg-base-200/30 p-8 md:flex-row md:border-4 md:p-12"
+			aria-label="User profile"
 		>
 			<!-- decorative left accent (sidebar-like) -->
 			<div
@@ -32,6 +33,7 @@
 								!effectiveReduceMotion,
 						}"
 						role="img"
+						:aria-label="`${user?.globalName ?? user?.username} avatar`"
 					>
 						<NuxtImg
 							v-if="isDefault"
@@ -90,6 +92,7 @@
 
 		<section
 			class="relative flex flex-col items-center justify-center divide-y divide-base-200/50 overflow-hidden rounded-xl border-2 border-base-200 bg-base-200/20 shadow-lg md:border-4"
+			aria-label="Account management"
 		>
 			<!-- subtle left accent to mirror dashboard sidebar -->
 			<div
@@ -151,6 +154,7 @@
 											:is-loading
 											is-loading-icon="lucide:loader"
 											icon="heroicons:shield-check"
+											aria-label="Toggle manageable servers only"
 											@click="toggleShowManageableOnly()"
 										/>
 
@@ -159,6 +163,7 @@
 											class="join-item"
 											color="primary"
 											:is-loading
+											aria-label="Toggle sort order"
 											@click="toggleSortOrder()"
 										>
 											<template #leading>
@@ -190,6 +195,7 @@
 											:is-loading
 											is-loading-icon="lucide:loader"
 											icon="heroicons:arrow-path-20-solid"
+											aria-label="Refresh servers"
 											@click="refresh()"
 										/>
 									</UFieldGroup>

--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -32,8 +32,6 @@
 							'transition-transform duration-300 group-hover:scale-105':
 								!effectiveReduceMotion,
 						}"
-						role="img"
-						:aria-label="`${user?.globalName ?? user?.username} avatar`"
 					>
 						<NuxtImg
 							v-if="isDefault"

--- a/shared/utils/settingsDataEntries.ts
+++ b/shared/utils/settingsDataEntries.ts
@@ -3,7 +3,7 @@ import type { Channels, Events, Moderation, Roles } from "../types/configurableD
 export const ConfigurableRemoveInitialRole: Roles.Role = {
 	key: "rolesRemoveInitial",
 	name: "Remove Initial",
-	tooltip: "Whether claiming a public role should remove the initial role at the same time.",
+	tooltip: "When enabled, claiming a public role automatically removes the initial role.",
 };
 
 export const ConfigurableRoles: Roles.Role[] = [
@@ -16,7 +16,7 @@ export const ConfigurableRoles: Roles.Role[] = [
 	{
 		key: "rolesInitial",
 		name: "Initial",
-		tooltip: "The initial role, if configured, I will give it to users as soon as they join.",
+		tooltip: "The initial role, if configured, is assigned to users as soon as they join.",
 	},
 	{
 		key: "rolesModerator",
@@ -28,7 +28,7 @@ export const ConfigurableRoles: Roles.Role[] = [
 		key: "rolesMuted",
 		name: "Muted",
 		tooltip:
-			"The muted role, if configured, I will give new muted users this role. Otherwise I will prompt you the creation of one.",
+			"The muted role, if configured, is assigned to muted users. If no muted role is set, you are prompted to create one.",
 	},
 	{
 		key: "rolesRestrictedReaction",
@@ -64,27 +64,27 @@ export const ConfigurableRoles: Roles.Role[] = [
 
 export const ConfigurableModerationKeys: Moderation.Message[] = [
 	{
-		description: "Will delete your message to hide the mod.",
+		description: "Deletes the command message to keep the moderator anonymous.",
 		key: "messagesModerationAutoDelete",
 		name: "Hide Message",
 	},
 	{
-		description: "DM's the punished person with the reason/duration.",
+		description: "Sends the punished member a DM with the reason and duration.",
 		key: "messagesModerationDm",
 		name: "Message User",
 	},
 	{
-		description: "Responds to the punishment command.",
+		description: "Posts a confirmation message after a punishment is applied.",
 		key: "messagesModerationMessageDisplay",
 		name: "Send Punishment Response",
 	},
 	{
-		description: "Whether to show the reason in the response.",
+		description: "Includes the reason in the punishment response message.",
 		key: "messagesModerationReasonDisplay",
 		name: "Show Reason",
 	},
 	{
-		description: "Whether to show the moderators name in the DM.",
+		description: "Includes the moderator's name in the DM sent to the punished member.",
 		key: "messagesModeratorNameDisplay",
 		name: "Show Mod Name",
 	},
@@ -92,12 +92,12 @@ export const ConfigurableModerationKeys: Moderation.Message[] = [
 
 export const ConfigurableModerationEvents: Events.Event[] = [
 	{
-		description: "This event posts anonymous moderation logs when a user gets banned.",
+		description: "An anonymous moderation log is posted when a member is banned.",
 		key: "eventsBanAdd",
 		title: "Ban Added",
 	},
 	{
-		description: "This event posts anonymous moderation logs when a user gets unbanned",
+		description: "An anonymous moderation log is posted when a member is unbanned.",
 		key: "eventsBanRemove",
 		title: "Ban Revoked",
 	},
@@ -106,7 +106,7 @@ export const ConfigurableModerationEvents: Events.Event[] = [
 export const ConfigurableMessageEvents: Events.Event[] = [
 	{
 		description:
-			"This event posts messages whenever a member reacts to a message with a twemoji, they will be send to the Reaction Logs channel",
+			"When a member reacts with a Twemoji, the reaction is sent to the Reaction Logs channel.",
 		key: "eventsTwemojiReactions",
 		title: "Twemoji Reactions",
 	},
@@ -114,161 +114,147 @@ export const ConfigurableMessageEvents: Events.Event[] = [
 
 export const ConfigurableLoggingChannels: Channels.Channel[] = [
 	{
-		description: "The channel I will send a message to when a member joins.",
+		description: "Receives a log message when a member joins the server.",
 		key: "channelsLogsMemberAdd",
 		name: "Member Add Logs",
 	},
 	{
-		description:
-			"The channel I will send a message to when a member leaves, is kicked, or is banned.",
+		description: "Receives a log message when a member leaves, is kicked, or is banned.",
 		key: "channelsLogsMemberRemove",
 		name: "Member Remove Logs",
 	},
 	{
-		description: "The channel I will send a message to when a member changes their nickname.",
+		description: "Receives a log message when a member changes their nickname.",
 		key: "channelsLogsMemberNicknameUpdate",
 		name: "Member Nickname Update Logs",
 	},
 	{
-		description: "The channel I will send a message to when a member changes their username.",
+		description: "Receives a log message when a member changes their username.",
 		key: "channelsLogsMemberUsernameUpdate",
 		name: "Member Username Update Logs",
 	},
 	{
-		description: "The channel I will send a message to when a member gets or loses a role.",
+		description: "Receives a log message when a member gains or loses a role.",
 		key: "channelsLogsMemberRolesUpdate",
 		name: "Member Role Logs",
 	},
 	{
-		description: "The channel I will send a message to when a message has been deleted.",
+		description: "Receives a log message when a message is deleted.",
 		key: "channelsLogsMessageDelete",
 		name: "Message Delete Logs",
 	},
 	{
-		description:
-			"The channel I will send a message to when a message from an NSFW channel has been deleted.",
+		description: "Receives a log message when a message from an NSFW channel is deleted.",
 		key: "channelsLogsMessageDeleteNsfw",
 		name: "NSFW Message Delete Logs",
 	},
 	{
-		description: "The channel I will send a message to when a message has been updated.",
+		description: "Receives a log message when a message is edited.",
 		key: "channelsLogsMessageUpdate",
 		name: "Message Update Logs",
 	},
 	{
-		description:
-			"The channel I will send a message to when a message from an NSFW channel has been updated.",
+		description: "Receives a log message when a message from an NSFW channel is edited.",
 		key: "channelsLogsMessageUpdateNsfw",
 		name: "NSFW Message Update Logs",
 	},
 	{
-		description:
-			"The channel for moderation logs, once enabled, I will post all my moderation cases there.",
+		description: "Receives all moderation case logs. Required for moderation events to work.",
 		key: "channelsLogsModeration",
 		name: "Moderation Logs",
 	},
 	{
-		description: "The channel I will use to re-upload all images I see.",
+		description: "Receives re-uploaded copies of images posted in the server.",
 		key: "channelsLogsImage",
 		name: "Image Logs",
 	},
 	{
-		description:
-			"The channel for prune logs, same requirement as normal message logs, but will only send prune messages.",
+		description: "Receives a log message when messages are bulk-deleted (pruned).",
 		key: "channelsLogsPrune",
 		name: "Prune Logs",
 	},
 	{
-		description:
-			"The channel for the reaction logs, same requirement as normal message logs, but will only send message reactions",
+		description: "Receives a log message when a reaction is added to a message.",
 		key: "channelsLogsReaction",
 		name: "Reaction Logs",
 	},
 	{
-		description:
-			"The channel for channel creation logs, if set, I will send a message when another channel is created.",
+		description: "Receives a log message when a new channel is created.",
 		key: "channelsLogsChannelCreate",
 		name: "Channel Create Logs",
 	},
 	{
 		description:
-			"The channel for channel update logs, if set, I will send a message to this channel when any channel (including this one) gets updated in any way. This message will contain the changes made to the channel.",
+			"Receives a log message when any channel is updated, including the changes made.",
 		key: "channelsLogsChannelUpdate",
 		name: "Channel Update Logs",
 	},
 	{
-		description:
-			"The channel for channel deletion logs, if set, I will send a message to this channel when another channel is deleted.",
+		description: "Receives a log message when a channel is deleted.",
 		key: "channelsLogsChannelDelete",
 		name: "Channel Delete Logs",
 	},
 	{
-		description:
-			"The channel for emoji creation logs, if set, I will send a message when an emoji has been created.",
+		description: "Receives a log message when a new emoji is created.",
 		key: "channelsLogsEmojiCreate",
 		name: "Emoji Create Logs",
 	},
 	{
-		description:
-			"The channel for emoji update logs, if set, I send a message when an emoji is updated in any way. This message will contain the changes made to the emoji.",
+		description: "Receives a log message when an emoji is updated, including the changes made.",
 		key: "channelsLogsEmojiUpdate",
 		name: "Emoji Update Logs",
 	},
 	{
-		description:
-			"The channel for emoji deletion logs, if set, I will send a message when an emoji is deleted.",
+		description: "Receives a log message when an emoji is deleted.",
 		key: "channelsLogsEmojiDelete",
 		name: "Emoji Delete Logs",
 	},
 	{
-		description:
-			"The channel for role creation logs, if set, I send a message when a new role is craeted.",
+		description: "Receives a log message when a new role is created.",
 		key: "channelsLogsRoleCreate",
 		name: "Role Create Logs",
 	},
 	{
-		description:
-			"The channel for role update logs, if set, I send a message when a role is updated in any way. This message will contain the changes made to the role.",
+		description: "Receives a log message when a role is updated, including the changes made.",
 		key: "channelsLogsRoleUpdate",
 		name: "Role Update Logs",
 	},
 	{
-		description:
-			"The channel for role deletion logs, if set, I send a message when a role is deleted.",
+		description: "Receives a log message when a role is deleted.",
 		key: "channelsLogsRoleDelete",
 		name: "Role Delete Logs",
 	},
 	{
 		description:
-			"The channel for server update logs, if set, I send a message when the server is updated in any way. This message will contain the changes made to the server.",
+			"Receives a log message when the server settings are updated, including the changes made.",
 		key: "channelsLogsServerUpdate",
 		name: "Server Update Logs",
 	},
 ];
 export const ConfigurableIgnoreChannels: Channels.IgnoreChannel[] = [
 	{
-		description: "Channels I should ignore for all types of logging.",
+		description: "Channels excluded from all types of logging.",
 		key: "channelsIgnoreAll",
 		name: "All logs",
 	},
 	{
-		description: "Channels I should ignore when checking for deleted messages to log.",
+		description: "Channels excluded from deleted-message logging.",
 		key: "channelsIgnoreMessageDelete",
 		name: "Message delete logs",
 	},
 	{
-		description: "Channels I should ignore when checking for edited messages to log.",
+		description: "Channels excluded from edited-message logging.",
 		key: "channelsIgnoreMessageEdit",
 		name: "Message edit logs",
 	},
 	{
-		description: "Channels I should ignore when checking for added reactions.",
+		description: "Channels excluded from reaction logging.",
 		key: "channelsIgnoreReactionAdd",
 		name: "Reaction add logs",
 	},
 	{
 		description:
-			"Channels I should ignore for all three of deleted messages to log, checking for editing messages to log, and checking for added reactions.",
+			"Channels excluded from message-delete, message-edit, and reaction-add logging.",
 		key: "messagesIgnoreChannels",
 		name: "Message Delete, Edit and Reaction Add logs",
 	},

--- a/shared/utils/settingsDataEntries.ts
+++ b/shared/utils/settingsDataEntries.ts
@@ -33,27 +33,27 @@ export const ConfigurableRoles: Roles.Role[] = [
 	{
 		key: "rolesRestrictedReaction",
 		name: "Restricted Reaction",
-		tooltip: "The role that is used for the restrictReaction moderation command.",
+		tooltip: "Assigned to members whose reactions are restricted.",
 	},
 	{
 		key: "rolesRestrictedEmbed",
 		name: "Restricted Embed",
-		tooltip: "The role that is used for the restrictEmbed moderation command.",
+		tooltip: "Assigned to members who are restricted from embedding links.",
 	},
 	{
 		key: "rolesRestrictedAttachment",
 		name: "Restricted Attachment",
-		tooltip: "The role that is used for the restrictAttachment moderation command.",
+		tooltip: "Assigned to members who are restricted from uploading attachments.",
 	},
 	{
 		key: "rolesRestrictedEmoji",
 		name: "Restricted Emoji",
-		tooltip: "The role that is used for the restrictEmoji moderation command.",
+		tooltip: "Assigned to members who are restricted from using external emojis.",
 	},
 	{
 		key: "rolesRestrictedVoice",
 		name: "Restricted Voice",
-		tooltip: "The role that is used for the restrictVoice moderation command.",
+		tooltip: "Assigned to members who are restricted from joining voice channels.",
 	},
 	{
 		key: "rolesPublic",


### PR DESCRIPTION
### Linked issue

Improves overall dashboard accessibility and UX copy consistency.

### Context

The dashboard had inconsistent and sometimes unclear descriptions across guild settings, filter components, and profile pages. Several accessibility gaps existed: no skip-to-content link, missing aria-labels on interactive elements, and redundant aria-label/title duplication on guild cards.

### Description

**Accessibility**
- Add skip-to-main-content link in the default layout (WCAG 2.4.1)
- Add `id="maincontent"` and `tabindex="-1"` to `<UMain>` for skip-link target
- Add `aria-label` to profile page sections and toolbar buttons (manageable toggle, sort order, refresh)
- Replace duplicated `aria-label`/`title` attributes on guild stat spans with `sr-only` text
- Change `role="status"` to `role="note"` on non-manageable guild indicator (not a live region)

**UX Copy**
- Rewrite all `settingsDataEntries.ts` descriptions from first-person bot voice ("I will send a message...") to impersonal active voice ("Receives a log message when...")
- Rewrite filter setting labels for clarity: "Maximum Threshold" -> "Violations before punishment", "Threshold Duration" -> "Time window (seconds)"
- Rewrite filter toggle descriptions: "Whether or not this system should be enabled" -> context-specific descriptions per filter
- Improve hard action and duration field descriptions
- Update aria-labels on filter sliders to match new label text

**Minor fixes**
- Standardize error toasts: "Could not save" -> "Couldn't save" across all settings components
- Include `wolfstarIsIn` in guild card `v-memo` dependency array to prevent stale renders
- Improve prefix field placeholder: "Enter prefix" -> "!"
- Rename "Ignore Channels" heading to "Excluded Channels"
- Improve Roles subtitle and section descriptions