### PR TITLE
feat(redirects): update footer links and add redirects for social media and GitHub

### DIFF
--- a/app/components/app/Footer.vue
+++ b/app/components/app/Footer.vue
@@ -56,7 +56,7 @@
 			<ColorModeButton />
 
 			<UButton
-				to="https://github.com/wolfstar-project/wolfstar"
+				to="https://repo.wolfstar.rocks"
 				target="_blank"
 				rel="noopener noreferrer"
 				icon="lucide:github"

--- a/app/components/guild/card.vue
+++ b/app/components/guild/card.vue
@@ -91,7 +91,10 @@
 
 			<!-- Desktop: Vertical layout (original) -->
 			<div class="hidden h-full w-full flex-col items-center gap-3 text-center md:flex">
-				<div class="flex flex-col items-center" :class="{ 'opacity-60': !guild.manageable }">
+				<div
+					class="flex flex-col items-center"
+					:class="{ 'opacity-60': !guild.manageable }"
+				>
 					<guild-icon :guild variant="bare" size="lg" :show-status="true" />
 				</div>
 				<!-- Guild Name -->

--- a/app/composables/useFooter.ts
+++ b/app/composables/useFooter.ts
@@ -8,14 +8,21 @@ export const useFooter = () => {
 					class: "link-hover",
 					icon: "ph:discord-logo-duotone",
 					label: "Support Server",
-					to: "https://join.wolfstar.rocks",
+					to: "https://chat.wolfstar.rocks",
 					ui: { linkLeadingIcon: "bg-indigo-500" },
+				},
+				{
+					class: "link-hover",
+					icon: "ph:twitter-logo-duotone",
+					label: "Twitter",
+					to: "https://social.wolfstar.rocks/twitter",
+					ui: { linkLeadingIcon: "bg-sky-400" },
 				},
 				{
 					class: "link-hover",
 					icon: "ph:github-logo-duotone",
 					label: "GitHub",
-					to: "https://github.com/wolfstar-project",
+					to: "https://repo.wolfstar.rocks",
 					ui: { linkLeadingIcon: "bg-indigo-500" },
 				},
 				{

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,21 @@ remote_images = [
 	"https:\\/\\/media.discordapp.net/.*",
 	"https:\\/\\/cdn.wolfstar.rocks/.*",
 ]
+
+[[redirects]]
+from = "https://repo.wolfstar.rocks"
+to = "https://github.com/wolfstar-project/wolfstar.rocks"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://chat.wolfstar.rocks"
+to = "https://discord.gg/gqAnRyUXG8"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://social.wolfstar.rocks/twitter"
+to = "https://twitter.com/WolfstarApp"
+status = 301
+force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,8 +16,8 @@ remote_images = [
 ]
 
 [[redirects]]
-from = "https://repo.wolfstar.rocks"
-to = "https://github.com/wolfstar-project/wolfstar.rocks"
+from = "https://repo.wolfstar.rocks/*"
+to = "https://github.com/wolfstar-project/wolfstar.rocks/:splat"
 status = 301
 force = true
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

The footer links pointed to raw external URLs (direct Discord invite link, bare GitHub org URL). This makes link management fragile — if any upstream URL changes, a code deploy is required.

This PR introduces Netlify 301 redirects behind branded subdomains (`chat.wolfstar.rocks`, `repo.wolfstar.rocks`, `social.wolfstar.rocks/twitter`) and updates footer links to use them. It also adds a new Twitter link to the footer for better social presence.

### 📚 Description

**Changes:**

- **`app/composables/useFooter.ts`:**
  - Updated the Discord support server link from `join.wolfstar.rocks` to `chat.wolfstar.rocks`.
  - Updated the GitHub link from `github.com/wolfstar-project` to `repo.wolfstar.rocks`.
  - Added a new Twitter footer link pointing to `social.wolfstar.rocks/twitter`.

- **`netlify.toml`:**
  - Added three permanent (301) redirects:
    - `repo.wolfstar.rocks` -> `github.com/wolfstar-project/wolfstar.rocks`
    - `chat.wolfstar.rocks` -> Discord invite link
    - `social.wolfstar.rocks/twitter` -> Twitter profile

**Why:**

Using branded redirect URLs decouples the application code from upstream service URLs. If a Discord invite or Twitter handle changes, only Netlify config needs updating — no app redeploy required. This also provides consistent branding across all external links.