### PR TITLE
ci(labelsync): enable label merging in workflow

### DIFF
--- a/.github/workflows/labelsync.yml
+++ b/.github/workflows/labelsync.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   label_sync:
-    uses: wolfstar-project/.github/.github/workflows/reusable-labelsync.yml@main
+    uses: wolfstar-project/.github/.github/workflows/reusable-labelsync.yml@fb3b0e52ddb109fec8a64f26a9295c9e72528dc8
     with:
       merge-labels: true

--- a/.github/workflows/labelsync.yml
+++ b/.github/workflows/labelsync.yml
@@ -12,3 +12,5 @@ permissions:
 jobs:
   label_sync:
     uses: wolfstar-project/.github/.github/workflows/reusable-labelsync.yml@main
+    with:
+      merge-labels: true


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

The labelsync workflow was not merging labels — only creating or deleting them. Enabling `merge-labels` aligns behavior with standard triage workflows where labels defined in the config file are merged rather than wholesale replaced.

### 📚 Description

Adds `merge-labels: true` to the `label_sync` job in `.github/workflows/labelsync.yml`. This passes the flag through to the reusable workflow so that labels are merged rather than replaced on each sync run.

Without this, any labels created outside the config file (for example by an automated triage bot or a repository admin) would be deleted on the next sync. With `merge-labels: true` those extra labels are preserved.