### PR TITLE
feat(workflows): add semantic PR validation and stale management

### DIFF
--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -1,0 +1,48 @@
+name: chore
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  semantic-pr:
+    permissions:
+      contents: read
+      pull-requests: read # for amannn/action-semantic-pull-request to analyze PRs
+      statuses: write # for amannn/action-semantic-pull-request to mark status of analyzed PR
+    if: github.repository == 'wolfstar-project/wolfstar.rocks'
+    runs-on: ubuntu-slim
+    name: 🏷️ Validate PR title
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        with:
+          scopes: |
+            a11y
+            blog
+            deps
+            docs
+            cli
+            i18n
+            ui
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+
+            Examples:
+              ✅ chore(ui): fix button spacing
+              ✅ docs: update README
+              ❌ chore(ui): Fix button spacing
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -1,4 +1,4 @@
-name: chore
+name: Semantic Pull Requests
 
 on:
   pull_request_target:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,7 +26,7 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
           remove-stale-when-updated: true
-          only-issue-types: "bug"
+          only-labels: "bug"
           stale-issue-label: "stale"
           close-issue-label: "stale"
           operations-per-run: 500

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,49 @@
+name: Stale Issues and PRs
+
+on:
+  schedule:
+    # Run daily at 2 AM UTC
+    - cron: "0 2 * * *"
+  workflow_dispatch: # Allow manual trigger
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  stale-bugs:
+    name: 🧹 Mark stale bug issues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # mark and close stale bug issues
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 7
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-stale-when-updated: true
+          only-issue-types: "bug"
+          stale-issue-label: "stale"
+          close-issue-label: "stale"
+          operations-per-run: 500
+
+  stale-prs:
+    name: 🧹 Mark stale pull requests
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # mark and close stale pull requests
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          remove-stale-when-updated: true
+          stale-pr-label: "stale"
+          close-pr-label: "stale"
+          operations-per-run: 500


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Two GitHub Actions workflows were missing from the repository: one to enforce conventional commit titles on pull requests, and one to automatically mark and close stale issues and pull requests. Both are standard automation present in wolfstar-project/.github.

### 📚 Description

Adds two new workflows:

**`semantic-pull-requests.yml`**
Validates pull request titles against the Conventional Commits spec using `amannn/action-semantic-pull-request@v6.1.1` (pinned by SHA). The workflow triggers on `pull_request_target` and checks:
- Title follows the `type(scope): subject` or `type: subject` format.
- Subject does not start with an uppercase letter.
- Scope is one of the project-approved list (`a11y`, `blog`, `deps`, `docs`, `cli`, `i18n`, `ui`).

Uses the minimum required permissions (`contents: read`, `pull-requests: read`, `statuses: write`).

**`stale.yml`**
Runs daily at 02:00 UTC and marks issues/PRs as stale after 30 days of inactivity, then closes them after 7 more days. The job is split into two focused jobs:
- `stale-bugs`: targets `bug` issues only, ignores PRs.
- `stale-prs`: targets pull requests only, ignores issues.

Both jobs use `actions/stale@v10.2.0` pinned by SHA and operate with the minimum required permissions.