### PR TITLE
style(ui): remove card-glass for cleaner ui

### DIFF
--- a/app/components/command/Base.vue
+++ b/app/components/command/Base.vue
@@ -1,5 +1,5 @@
 <template>
-	<article class="space-y-8 card-glass rounded-2xl p-6" aria-label="Command details">
+	<article class="space-y-8 rounded-2xl p-6" aria-label="Command details">
 		<!-- Loading Skeleton -->
 		<template v-if="loading">
 			<!-- Command Usage Skeleton -->

--- a/app/components/command/Base.vue
+++ b/app/components/command/Base.vue
@@ -79,7 +79,7 @@
 						v-for="(usage, idx) in command.extendedHelp.usages"
 						:key="idx"
 						role="listitem"
-						class="block card-glass rounded-xl border border-base-content/10 bg-base-300/70 px-5 py-4 font-mono text-sm text-base-content transition-all"
+						class="block rounded-xl border border-base-content/10 bg-base-300/70 px-5 py-4 font-mono text-sm text-base-content transition-all"
 					>
 						<span class="text-primary">WolfStar</span>,
 						<span class="text-primary/80">{{ command.name }}</span>
@@ -100,9 +100,7 @@
 					</div>
 					<span>Extended Help</span>
 				</h3>
-				<div
-					class="card-glass rounded-xl border border-base-300/50 bg-base-200/30 px-5 py-4 dark:border-base-content/10 dark:bg-base-300/30"
-				>
+				<div class="rounded-xl border border-base-content/10 bg-base-200/30 px-5 py-4">
 					<div class="prose max-w-none dark:prose-invert prose-p:leading-relaxed">
 						<div
 							class="text-base leading-7 whitespace-pre-line"
@@ -132,7 +130,7 @@
 					<div
 						v-for="([arg, desc], idx) in command.extendedHelp.explainedUsage"
 						:key="idx"
-						class="card-glass rounded-r-xl border-l-4 border-primary/50 bg-primary/5 py-3 pr-4 pl-5 transition-all dark:bg-primary/10"
+						class="rounded-r-xl border-l-4 border-primary/50 bg-primary/5 py-3 pr-4 pl-5 transition-all"
 					>
 						<dt class="mb-1 text-base font-semibold text-primary">
 							{{ arg }}
@@ -162,7 +160,7 @@
 					<div
 						v-for="([type, example], idx) in command.extendedHelp.possibleFormats"
 						:key="idx"
-						class="card-glass rounded-r-xl border-l-4 border-primary/50 bg-primary/5 py-3 pr-4 pl-5 transition-all dark:bg-primary/10"
+						class="rounded-r-xl border-l-4 border-primary/50 bg-primary/5 py-3 pr-4 pl-5 transition-all"
 					>
 						<dt class="mb-1 text-base font-semibold text-primary">
 							{{ type }}
@@ -190,7 +188,7 @@
 					<li
 						v-for="(example, idx) in command.extendedHelp.examples"
 						:key="idx"
-						class="flex items-start gap-3 card-glass rounded-xl border border-primary/20 bg-primary/5 p-4 text-sm transition-all dark:border-primary/30 dark:bg-primary/10"
+						class="flex items-start gap-3 rounded-xl border border-primary/20 bg-primary/5 p-4 text-sm transition-all"
 					>
 						<UIcon
 							name="i-heroicons-arrow-right"
@@ -218,9 +216,7 @@
 					</div>
 					<span>Reminder</span>
 				</h3>
-				<div
-					class="card-glass rounded-xl border border-primary/20 bg-primary/5 p-5 transition-all dark:border-primary/30 dark:bg-primary/10"
-				>
+				<div class="rounded-xl border border-primary/20 bg-primary/5 p-5 transition-all">
 					<div
 						class="prose max-w-none text-sm leading-relaxed text-base-content/90 dark:prose-invert prose-p:m-0"
 						v-html="sanitizeAndFormat(command.extendedHelp.reminder)"

--- a/app/components/command/SubCategory.vue
+++ b/app/components/command/SubCategory.vue
@@ -91,7 +91,7 @@
 	</div>
 	<div
 		v-else-if="searchValue"
-		class="card-glass rounded-2xl px-6 py-12 text-center"
+		class="rounded-2xl bg-base-200/30 px-6 py-12 text-center"
 		role="status"
 	>
 		<UIcon

--- a/app/components/command/SubCategory.vue
+++ b/app/components/command/SubCategory.vue
@@ -10,7 +10,7 @@
 				root: 'space-y-3',
 				item: '',
 				content:
-					'card-glass rounded-2xl overflow-hidden transition-all border border-base-content/10',
+					'rounded-2xl rounded-t-none overflow-hidden transition-all border border-t-0 border-base-content/10 bg-base-200/30',
 			}"
 			class="animate-fade-in"
 		>
@@ -18,7 +18,8 @@
 				<UButton
 					color="neutral"
 					variant="ghost"
-					class="w-full justify-between rounded-xl border border-base-content/5 bg-base-200/50 px-6 py-4 transition-all hover:bg-base-200/80 dark:bg-base-300/30 dark:hover:bg-base-300/50"
+					class="w-full justify-between rounded-2xl border border-base-content/10 bg-base-200/50 px-6 py-4 transition-all hover:bg-base-200/80"
+					:class="{ 'rounded-b-none': open }"
 					:aria-expanded="open"
 					:aria-controls="`category-content-${item.value.replace(/\s+/g, '-').toLowerCase()}`"
 				>
@@ -58,7 +59,7 @@
 							item: 'border-0',
 							content: 'border-0 pt-4',
 							trigger:
-								'bg-base-content/10 hover:bg-base-content/15 dark:bg-base-content/5 dark:hover:bg-base-content/10 px-5 py-4 rounded-xl hover-lift transition-all w-full border border-base-content/10',
+								'bg-base-content/10 hover:bg-base-content/15 px-5 py-4 rounded-xl hover-lift transition-all w-full border border-base-content/10',
 							trailingIcon: 'text-base-content/60 size-5 shrink-0',
 							label: 'flex items-center gap-4 flex-1 min-w-0',
 						}"


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

The `card-glass` utility class was applied broadly across the command viewer components, adding a frosted-glass backdrop filter to every card, section, and list item. This created visual noise and inconsistency — especially in light mode where the glass effect produced unintended contrast against the page background.

### 📚 Description

Removes all `card-glass` class usages from `Base.vue` and `SubCategory.vue`, replacing the glass styling with plain surface tokens already present in the design system (`bg-base-200/30`, `bg-base-300/70`, `bg-primary/5`).

Changes in `Base.vue`:
- Usage code blocks: dropped `card-glass`, kept border and background tokens.
- Extended help container: simplified to a single `div` with a flat border and background.
- Explained usage and possible formats items: removed `card-glass` and dark-mode overrides that are now redundant.
- Examples list items: removed `card-glass` and dark-mode duplicates.
- Reminder container: removed `card-glass` and dark-mode duplicates.

Changes in `SubCategory.vue`:
- Accordion content panel: replaced `card-glass` with `bg-base-200/30`, removed top border and added `rounded-t-none` so the open panel connects seamlessly to its trigger button.
- Accordion trigger button: changed from `rounded-xl` to `rounded-2xl`, added `rounded-b-none` binding when open, removed dark-mode overrides now handled by the design tokens.
- Inner trigger slots: removed `dark:` overrides that duplicated the default state.