### PR TITLE
style(css): add stable scrollbar gutter to html element

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -121,6 +121,10 @@
 		--branding-staryl: oklch(0.5873 0.0204 272.13);
 	}
 
+	html {
+		scrollbar-gutter: stable;
+	}
+
 	::-webkit-scrollbar {
 		width: 5px;
 		height: 2px;


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

Without `scrollbar-gutter: stable`, pages that transition between scrollable and non-scrollable states cause a layout shift as the scrollbar appears and disappears. This is noticeable on route changes and modal open/close.

### 📚 Description

Adds `scrollbar-gutter: stable` to the `html` element in `app/assets/css/main.css`. This reserves space for the scrollbar at all times, preventing the content area from reflowing when the scrollbar is shown or hidden.

The change is a single CSS declaration. It has no effect on browsers that do not support `scrollbar-gutter` (all major browsers since 2022 support it).