### PR TITLE
chore(vscode): update MCP server configuration

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,22 +1,42 @@
 {
 	"servers": {
+		"nuxt": {
+			"type": "http",
+			"url": "https://nuxt.com/mcp",
+			"tools": ["*"]
+		},
 		"daisyUI": {
 			"type": "http",
-			"url": "https://gitmcp.io/saadeghi/daisyui"
+			"url": "https://gitmcp.io/saadeghi/daisyui",
+			"tools": ["*"]
 		},
+		"nuxt-ui": {
+			"type": "http",
+			"url": "https://ui.nuxt.com/mcp",
+			"tools": ["*"]
+		},
+
 		"browsermcp": {
 			"type": "stdio",
 			"command": "npx",
-			"args": ["-y", "@browsermcp/mcp@latest"]
+			"args": ["-y", "@browsermcp/mcp@latest"],
+			"tools": ["*"]
 		},
 		"sentry": {
-			"type": "http",
-			"url": "https://mcp.sentry.dev/mcp"
+			"type": "stdio",
+			"command": "npx",
+			"tools": ["*"],
+			"args": ["@sentry/mcp-server@latest", "--host=$SENTRY_HOST"],
+			"env": {
+				"SENTRY_HOST": "https://wolfstar-3t.sentry.io",
+				"SENTRY_ACCESS_TOKEN": "$COPILOT_MCP_SENTRY_ACCESS_TOKEN"
+			}
 		},
 		"chrome-devtools": {
 			"type": "stdio",
 			"command": "npx",
-			"args": ["-y", "chrome-devtools-mcp@latest"]
+			"args": ["-y", "chrome-devtools-mcp@latest"],
+			"tools": ["*"]
 		}
 	},
 	"inputs": []


### PR DESCRIPTION
## Summary

Updates `.vscode/mcp.json` with expanded MCP server coverage and consistent configuration.

## What changed

- Added **nuxt** MCP server (`https://nuxt.com/mcp`) for Nuxt framework docs
- Added **nuxt-ui** MCP server (`https://ui.nuxt.com/mcp`) for Nuxt UI component docs
- Switched **sentry** from HTTP endpoint to `stdio` via `npx @sentry/mcp-server`, with scoped host/token env vars (`SENTRY_HOST`, `SENTRY_ACCESS_TOKEN`)
- Added `"tools": ["*"]` to all server entries for full tool access

## Verification

- No runtime code changed -- VS Code workspace configuration only
- `pnpm lint`, `pnpm typecheck`, `pnpm build` unaffected