### PR TITLE
chore: add minimumReleaseAge and clean up config comments

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# pnpm v11: auth and registry settings only.
-# Hoisting and other config has been moved to pnpm-workspace.yaml.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,6 @@ allowedDeprecatedVersions:
     inflight: 1.0.6
     sourcemap-codec: 1.4.8
 
-# pnpm v11: hoisting config must live here (no longer read from .npmrc)
 shamefullyHoist: true
 hoistPattern:
     - "*prisma*"
@@ -34,7 +33,6 @@ peerDependencyRules:
 
 shellEmulator: true
 
-# pnpm v11: allowBuilds replaces onlyBuiltDependencies + ignoredBuiltDependencies
 allowBuilds:
     "@parcel/watcher": false
     "@prisma/client": true
@@ -51,3 +49,12 @@ allowBuilds:
     unrs-resolver: false
     vue-demi: false
     workerd: true
+
+minimumReleaseAge: 2880
+
+minimumReleaseAgeExclude:
+    # Nuxt
+    - "@nuxt/*"
+    - "@nuxtjs/*"
+    - "nuxt"
+    - "nuxt-*"


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

pnpm supports a `minimumReleaseAge` option that prevents installing packages published less than N minutes ago. This adds a 48-hour (2880 min) minimum release age as a supply-chain security measure, while excluding Nuxt-family packages that release frequently and are trusted.

The `.npmrc` file is removed because it only contained comments about pnpm v11 migration (the actual config already lives in `pnpm-workspace.yaml`). Stale inline comments are also removed from `pnpm-workspace.yaml` to reduce noise.

### 📚 Description

- Remove `.npmrc` (file contained only migration comments, no functional config)
- Remove stale pnpm v11 migration comments from `pnpm-workspace.yaml`
- Add `minimumReleaseAge: 2880` (48 hours) to guard against typosquatting / newly-published malicious packages
- Add `minimumReleaseAgeExclude` allowlist for `@nuxt/*`, `@nuxtjs/*`, `nuxt`, and `nuxt-*` packages so Nuxt releases are not delayed