### PR TITLE
fix: improve release workflow and fix release-notes output

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -7,14 +7,14 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions: {}
 
 jobs:
   tag:
     name: 🏷️ Tag release and create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'wolfstar-project/wolfstar.rocks'
     permissions:
       contents: write # create release tags and GitHub releases

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -73,6 +73,7 @@ async function main() {
 	const to = process.argv[3] || "HEAD";
 
 	if (!from) {
+		console.error("Usage: node scripts/release-notes.ts <from-ref> [to-ref]");
 		process.exit(1);
 	}
 
@@ -105,8 +106,11 @@ async function main() {
 			output += `\n### ❤️ Contributors\n\n${lines}`;
 		}
 	}
+
+	console.log(output);
 }
 
 main().catch((err) => {
+	console.error(err);
 	process.exit(1);
 });


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

The release workflow had two minor inefficiencies and the `release-notes.ts` script had a bug where generated output was never printed to stdout.

### 📚 Description

**Workflow (`release-tag.yml`):**
- Set `cancel-in-progress: true` so that triggering a new release cancels any still-running release job, avoiding redundant concurrent runs.
- Switch runner from `ubuntu-latest` to `ubuntu-slim` for a smaller, faster runner image.

**Script (`scripts/release-notes.ts`):**
- Fix missing `console.log(output)` call — the script computed the release notes but never actually printed them.
- Add a usage error message when the required `from-ref` argument is missing.
- Add `console.error(err)` in the top-level catch block so errors are visible instead of silently swallowed.
