### PR TITLE
chore(cursor): add MCP server config for Cursor IDE

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,29 @@
+{
+	"mcpServers": {
+		"nuxt": {
+			"type": "http",
+			"url": "https://nuxt.com/mcp"
+		},
+		"daisyUI": {
+			"type": "http",
+			"url": "https://gitmcp.io/saadeghi/daisyui"
+		},
+		"nuxt-ui": {
+			"type": "http",
+			"url": "https://ui.nuxt.com/mcp"
+		},
+		"browsermcp": {
+			"type": "stdio",
+			"command": "npx",
+			"args": ["-y", "@browsermcp/mcp@latest"]
+		},
+		"sentry": {
+			"url": "https://mcp.sentry.dev/mcp"
+		},
+		"chrome-devtools": {
+			"type": "stdio",
+			"command": "npx",
+			"args": ["-y", "chrome-devtools-mcp@latest"]
+		}
+	}
+}


### PR DESCRIPTION
### 🔗 Linked issue

#XXXX

### 🧭 Context

Cursor IDE contributors need a shared MCP configuration so agents can access the same documentation and tooling servers already defined for VS Code.

Adds `.cursor/mcp.json` with HTTP and stdio MCP servers for Nuxt, daisyUI, Nuxt UI, Browser MCP, Sentry, and Chrome DevTools.

### 📚 Description

This change introduces a project-level Cursor MCP config that mirrors the intent of `.vscode/mcp.json` while using Cursor's `mcpServers` schema.

Included servers:

- **nuxt** / **nuxt-ui** / **daisyUI** — HTTP MCP endpoints for framework and component docs
- **browsermcp** / **chrome-devtools** — stdio MCP for browser automation and DevTools
- **sentry** — HTTP MCP via Sentry's hosted endpoint (no repo secrets required in the config file)

Sentry is configured via Cursor's OAuth flow at `https://mcp.sentry.dev/mcp` rather than the VS Code stdio + env-token setup, since Cursor does not share VS Code's `inputs` / `$COPILOT_MCP_*` variable substitution.

No application runtime behavior changes — this is developer tooling only.
