### PR TITLE
chore(github): improve bug report issue form template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.yml
@@ -1,18 +1,31 @@
-name: Websites bug report
-description: Report an issue with the main website or other related issues.
-labels: [bug, need repro]
+name: Bug Report
+description: File a bug report for the WolfStar.rocks website or related issues.
+title: "[Bug]: "
+labels: ["bug", "need repro"]
+type: bug
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for filing an issue! If you are here to ask a question, use Discord instead: https://join.wolfstar.rocks
+        Thanks for taking the time to fill out this bug report!
 
-        This issue form is for our main website and other related issues.
-  - type: textarea
-    id: description
+        If you are here to ask a question, use Discord instead: https://join.wolfstar.rocks
+
+        This form is for issues with the main website and other related problems.
+  - type: checkboxes
+    id: duplicate-search
     attributes:
-      label: Issue description
-      description: Describe the issue in as much detail as possible.
+      label: Is there an existing issue for this?
+      description: Please search [existing issues](https://github.com/wolfstar-project/wolfstar.rocks/issues) to see if someone already reported this bug.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe what you saw. Also tell us what you expected to happen.
+      placeholder: Tell us what you see!
     validations:
       required: true
   - type: textarea
@@ -26,24 +39,73 @@ body:
         3. ...
     validations:
       required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Where are you seeing the problem?
+      description: Which deployment or environment is affected?
+      options:
+        - Production (wolfstar.rocks)
+        - Local development
+        - Preview / staging deploy
+        - Not sure
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on?
+      description: Select all that apply.
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Other
+    validations:
+      required: true
   - type: textarea
     id: versions
     attributes:
-      label: Versions
-      description: List necessary versions here. This includes your browser, operating system etc.
+      label: Environment details
+      description: List any helpful version details, such as browser build, operating system, or device.
       placeholder: |
-        - Safari 16.4 (18615.1.26.11.23)
-        - macOS Ventura 13.3.1
+        - Safari 18.4
+        - macOS Sequoia 15.4
+        - iPhone 16 / iOS 18.4
     validations:
       required: true
   - type: dropdown
     id: priority
     attributes:
       label: Issue priority
-      description: Please be realistic. If you need to elaborate on your reasoning, please use the issue description field above.
+      description: Please be realistic. If you need to elaborate on your reasoning, use the description fields above.
       options:
         - Low (slightly annoying)
         - Medium (should be fixed soon)
         - High (immediate attention needed)
     validations:
       required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant console or terminal output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: upload
+    id: screenshots
+    attributes:
+      label: Upload screenshots
+      description: If applicable, add screenshots to help explain your problem.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/wolfstar-project/wolfstar.rocks/blob/main/.github/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🔗 Linked issue

N/A — proactive template improvement.

### 🧭 Context

The bug report issue form was missing GitHub issue form top-level fields (`title`, `type`) and several structured inputs recommended in the [issue form syntax docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).

### 📚 Description

Updates `.github/ISSUE_TEMPLATE/01-bug_report.yml` to align with GitHub issue form best practices:

- **`title: "[Bug]: "`** — pre-populates the issue title prefix for consistent triage
- **`type: bug`** — sets the organization issue type automatically
- **Duplicate search checkbox** — asks reporters to search existing issues first
- **"What happened?" field** — combines observed vs. expected behavior in one required textarea
- **Environment dropdown** — production, local dev, preview/staging, or not sure
- **Browser multi-select dropdown** — Firefox, Chrome, Safari, Edge, Other
- **Environment details textarea** — browser build, OS, device info
- **Log output field** — `render: shell` for console/terminal output
- **Screenshot upload** — optional file attachment field
- **Code of Conduct checkbox** — links to the repo's `CODE_OF_CONDUCT.md`

Existing fields retained: steps to reproduce, priority dropdown, Discord redirect note, and `bug` / `need repro` labels.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce96ea3f-94f5-453a-9780-56c761958e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce96ea3f-94f5-453a-9780-56c761958e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

