### PR TITLE
fix(auth): use interactive Discord bot invite

### DIFF
--- a/app/components/guild/card.vue
+++ b/app/components/guild/card.vue
@@ -58,6 +58,7 @@
 				<NuxtLink
 					v-else-if="guild.manageable"
 					:to="guildAddURL(guild.id)"
+					external
 					class="group relative"
 					:aria-label="`Invite bot to ${guild.name}`"
 				>
@@ -145,6 +146,7 @@
 					<NuxtLink
 						v-else-if="guild.manageable"
 						:to="guildAddURL(guild.id)"
+						external
 						class="flex h-9 w-full items-center justify-center rounded-lg border border-primary/20 bg-primary/10 px-3 text-xs font-medium text-primary transition-all duration-200 group-hover:bg-primary/20 hover:shadow-md"
 						:aria-label="`Invite WolfStar bot to ${guild.name}`"
 					>

--- a/app/composables/auth.ts
+++ b/app/composables/auth.ts
@@ -3,12 +3,11 @@ import { withQuery } from "ufo";
 export function guildAddURL(guildID: string) {
 	return withQuery("https://discord.com/oauth2/authorize", {
 		client_id: getClientId(),
+		disable_guild_select: "true",
 		guild_id: guildID,
+		integration_type: "0",
 		permissions: "491121748",
-		prompt: "none",
-		redirect_uri: `${getOrigin()}/oauth/guild`,
-		response_type: "code",
-		scope: "bot",
+		scope: "bot applications.commands",
 	});
 }
 

--- a/test/nuxt/composables/auth.spec.ts
+++ b/test/nuxt/composables/auth.spec.ts
@@ -21,24 +21,25 @@ describe("guildAddURL", () => {
 		expect(url).toContain("permissions=491121748");
 	});
 
-	it("should include a redirect_uri ending with /oauth/guild", () => {
-		const url = guildAddURL("123");
-		expect(url).toMatch(/redirect_uri=.*%2Foauth%2Fguild/);
-	});
-
-	it("should include scope=bot", () => {
+	it("should include bot and command scopes", () => {
 		const url = guildAddURL("123");
 		expect(url).toContain("scope=bot");
+		expect(url).toContain("applications.commands");
 	});
 
-	it("should include response_type=code", () => {
+	it("should lock the install to the selected guild", () => {
 		const url = guildAddURL("123");
-		expect(url).toContain("response_type=code");
+		expect(url).toContain("disable_guild_select=true");
+		expect(url).toContain("integration_type=0");
 	});
 
-	it("should include prompt=none", () => {
+	it("should not force a non-interactive code grant flow", () => {
 		const url = guildAddURL("123");
-		expect(url).toContain("prompt=none");
+		const parsedUrl = new URL(url);
+
+		expect(parsedUrl.searchParams.has("prompt")).toBe(false);
+		expect(parsedUrl.searchParams.has("response_type")).toBe(false);
+		expect(parsedUrl.searchParams.has("redirect_uri")).toBe(false);
 	});
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🔗 Linked issue

Resolves #225

### 🧭 Context

The profile server card invite URL used `prompt=none` with the `bot` scope, but Discord requires user authorization for passthrough scopes like `bot`. That can leave the Add Bot modal in a broken non-interactive flow.

### 📚 Description

- Updates `guildAddURL()` to generate an interactive Discord guild install URL with `bot applications.commands`, guild install context, and locked guild selection.
- Removes the silent/code-grant parameters from the bot invite URL (`prompt`, `response_type`, `redirect_uri`).
- Marks profile guild invite links as external so Nuxt routing/view transitions do not handle Discord navigation.
- Updates the Nuxt composable contract tests for the new URL shape.

Validation:
- `pnpm test:nuxt -- test/nuxt/composables/auth.spec.ts` passed.
- `NUXT_PUBLIC_SITE_URL=http://localhost:3000 NUXT_PUBLIC_API_BASE_URL=http://localhost:8282 pnpm build` passed.
- `pnpm test` passed.
- `pnpm lint:fix` passed with existing console warnings in `server/plugins/evlog-drain.ts`.
- `pnpm typecheck` remains blocked by unrelated repo-wide TypeScript errors outside this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fda11bf2-003f-4543-957b-bbae3c41d9b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fda11bf2-003f-4543-957b-bbae3c41d9b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

