### PR TITLE
fix(discord): remove stale servers from profile after bot leaves

### DIFF
--- a/server/api/users/index.get.ts
+++ b/server/api/users/index.get.ts
@@ -1,3 +1,4 @@
+import { invalidateGuildCache, shouldRefreshCurrentUserCache } from "#server/utils/discord/cache";
 import { createError, useLogger } from "evlog";
 
 export default defineWrappedResponseHandler(
@@ -5,6 +6,10 @@ export default defineWrappedResponseHandler(
 		const log = useLogger(event);
 
 		const { user, guilds } = await getCurrentUser(event);
+
+		if (shouldRefreshCurrentUserCache(event)) {
+			await Promise.all(guilds.map((guild) => invalidateGuildCache(guild.id)));
+		}
 
 		log.set({ user: { id: user.id } });
 		log.set({ result: { guildCount: guilds.length } });

--- a/server/utils/discord/index.ts
+++ b/server/utils/discord/index.ts
@@ -1,3 +1,4 @@
+// oxlint-disable no-console
 import type { ReadonlyGuildData } from "#server/database";
 import type {
 	FlattenedGuild,
@@ -152,7 +153,9 @@ export async function transformGuild(
 		prefetchedSettings,
 	} = options;
 	const guild =
-		prefetchedGuild !== undefined ? prefetchedGuild : await fetchBotGuildFromDiscord(data.id);
+		prefetchedGuild !== undefined
+			? prefetchedGuild
+			: (await probeBotGuildMembership(data.id)).guild;
 
 	const channels =
 		includeChannels && !isNullOrUndefined(guild)
@@ -227,8 +230,8 @@ export async function transformOauthGuildsAndUser({
 	// Phase 1: Live bot-membership probe for every guild. Cached getGuild can stay
 	// positive for up to an hour after the bot leaves, which caused stale profile lists.
 	const guildData = await mapWithConcurrency(guilds, 16, async (g) => {
-		const guild = await fetchBotGuildFromDiscord(g.id);
-		if (!guild) {
+		const { guild, confirmedAbsent } = await probeBotGuildMembership(g.id);
+		if (confirmedAbsent) {
 			await invalidateGuildCache(g.id);
 		}
 		return guild;
@@ -436,12 +439,32 @@ export const getGuild = defineCachedFunction(
 	},
 );
 
+/**
+ * Live-probes bot guild membership. Returns `confirmedAbsent: true` only when
+ * Discord responds 404 (bot not in guild). On transient probe failures, falls
+ * back to the cached `getGuild` entry so a valid cache is not discarded.
+ */
+async function probeBotGuildMembership(
+	guildId: string,
+): Promise<{ guild: APIGuild | null; confirmedAbsent: boolean }> {
+	try {
+		const guild = await fetchBotGuildFromDiscord(guildId);
+		return { guild, confirmedAbsent: guild === null };
+	} catch (error) {
+		logger.warn(`[discord] Live guild probe failed for ${guildId}, falling back to cache`, {
+			error,
+		});
+		const guild = await getGuild(guildId).catch(() => null);
+		return { guild, confirmedAbsent: false };
+	}
+}
+
 export async function resolveGuildForRequest(event: H3Event, guildId: string) {
 	if (shouldRefreshGuildCache(event)) {
 		await invalidateGuildCache(guildId);
 	}
-	const guild = await fetchBotGuildFromDiscord(guildId);
-	if (!guild) {
+	const { guild, confirmedAbsent } = await probeBotGuildMembership(guildId);
+	if (confirmedAbsent) {
 		await invalidateGuildCache(guildId);
 		return null;
 	}

--- a/server/utils/discord/index.ts
+++ b/server/utils/discord/index.ts
@@ -152,14 +152,7 @@ export async function transformGuild(
 		prefetchedSettings,
 	} = options;
 	const guild =
-		prefetchedGuild !== undefined
-			? prefetchedGuild
-			: await getGuild(data.id).catch((error) => {
-					// getGuild already converts 404s to null; only handle unexpected 404s here
-					if (error?.status === 404 || error?.cause?.status === 404) return null;
-					// Rethrow all other errors (5xx, timeouts, etc.)
-					throw error;
-				});
+		prefetchedGuild !== undefined ? prefetchedGuild : await fetchBotGuildFromDiscord(data.id);
 
 	const channels =
 		includeChannels && !isNullOrUndefined(guild)
@@ -231,17 +224,15 @@ export async function transformOauthGuildsAndUser({
 
 	const userId = user.id;
 
-	// Phase 1: Fetch guild presence data for all guilds concurrently.
-	// getGuild returns null (cached) for guilds the bot is not in, eliminating
-	// repeated uncached 404 Discord API calls on every request.
-	const guildData = await mapWithConcurrency(guilds, 16, (g) =>
-		getGuild(g.id).catch((error) => {
-			// getGuild already converts 404s to null; only handle unexpected 404s here
-			if (error?.status === 404 || error?.cause?.status === 404) return null;
-			// Rethrow all other errors (5xx, timeouts, etc.)
-			throw error;
-		}),
-	);
+	// Phase 1: Live bot-membership probe for every guild. Cached getGuild can stay
+	// positive for up to an hour after the bot leaves, which caused stale profile lists.
+	const guildData = await mapWithConcurrency(guilds, 16, async (g) => {
+		const guild = await fetchBotGuildFromDiscord(g.id);
+		if (!guild) {
+			await invalidateGuildCache(g.id);
+		}
+		return guild;
+	});
 
 	// Phase 2: Fetch member data only for bot-present guilds where the user is not owner.
 	// Separates the sequential getGuild→getMember chain into two independent parallel phases.
@@ -414,29 +405,29 @@ export const getGuildChannels = defineCachedFunction(
 	},
 );
 
+export async function fetchBotGuildFromDiscord(guildId: string): Promise<APIGuild | null> {
+	const api = useApi();
+	Sentry.metrics.count("discord_api.call", 1, {
+		attributes: { endpoint: "guilds.get", guild_id: guildId },
+	});
+	return instrumentDiscordApiCall(
+		"guilds.get",
+		() => api.guilds.get(guildId, { with_counts: true }),
+		{ guild_id: guildId },
+	).catch((error: DiscordAPIError) => {
+		// 404 means the bot is not a member of this guild.
+		if (error.status === 404) return null;
+		throw createError({
+			cause: error,
+			message: `Failed to fetch guild: ${guildId}`,
+			status: 500,
+			why: "Discord API returned an error when fetching guild data",
+		});
+	});
+}
+
 export const getGuild = defineCachedFunction(
-	async (guildId: string) => {
-		const api = useApi();
-		Sentry.metrics.count("discord_api.call", 1, {
-			attributes: { endpoint: "guilds.get", guild_id: guildId },
-		});
-		const result = await instrumentDiscordApiCall(
-			"guilds.get",
-			() => api.guilds.get(guildId, { with_counts: true }),
-			{ guild_id: guildId },
-		).catch((error: DiscordAPIError) => {
-			// 404 means the bot is not a member of this guild. Do not cache null — membership
-			// can change immediately after a bot invite.
-			if (error.status === 404) return null;
-			throw createError({
-				cause: error,
-				message: `Failed to fetch guild: ${guildId}`,
-				status: 500,
-				why: "Discord API returned an error when fetching guild data",
-			});
-		});
-		return result;
-	},
+	async (guildId: string) => fetchBotGuildFromDiscord(guildId),
 	{
 		name: GUILD_CACHE_NAME,
 		maxAge: hours(1),
@@ -449,7 +440,12 @@ export async function resolveGuildForRequest(event: H3Event, guildId: string) {
 	if (shouldRefreshGuildCache(event)) {
 		await invalidateGuildCache(guildId);
 	}
-	return getGuild(guildId);
+	const guild = await fetchBotGuildFromDiscord(guildId);
+	if (!guild) {
+		await invalidateGuildCache(guildId);
+		return null;
+	}
+	return guild;
 }
 
 export const fetchCommands = defineCachedFunction(

--- a/server/utils/discord/index.ts
+++ b/server/utils/discord/index.ts
@@ -451,7 +451,7 @@ async function probeBotGuildMembership(
 		const guild = await fetchBotGuildFromDiscord(guildId);
 		return { guild, confirmedAbsent: guild === null };
 	} catch (error) {
-		logger.warn(`[discord] Live guild probe failed for ${guildId}, falling back to cache`, {
+		console.warn(`[discord] Live guild probe failed for ${guildId}, falling back to cache`, {
 			error,
 		});
 		const guild = await getGuild(guildId).catch(() => null);

--- a/server/utils/discord/index.ts
+++ b/server/utils/discord/index.ts
@@ -432,7 +432,7 @@ export const getGuild = defineCachedFunction(
 		name: GUILD_CACHE_NAME,
 		maxAge: hours(1),
 		getKey: (guildId) => `guild:${guildId}`,
-		validate: (entry) => entry.value !== null && entry.value !== undefined,
+		validate: (entry) => !isNullOrUndefined(entry.value),
 	},
 );
 

--- a/test/unit/server/utils/discord/transform-guild.spec.ts
+++ b/test/unit/server/utils/discord/transform-guild.spec.ts
@@ -3,11 +3,30 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // All Nuxt server auto-import globals that discord.ts uses at module-init time
 // (defineCachedFunction / hours) must be present before the module is evaluated.
 // vi.hoisted() runs before any static import is resolved.
-const { mockGetChannels, mockGuildsGet } = vi.hoisted(() => {
+const { mockGetChannels, mockGuildsGet, guildCache } = vi.hoisted(() => {
 	const mockGetChannels = vi.fn();
 	const mockGuildsGet = vi.fn();
+	const guildCache = new Map<string, unknown>();
 
-	(globalThis as Record<string, unknown>).defineCachedFunction = (fn: unknown) => fn;
+	(globalThis as Record<string, unknown>).defineCachedFunction = (
+		fn: (...args: unknown[]) => unknown,
+		opts?: {
+			getKey?: (...args: unknown[]) => string;
+			validate?: (entry: { value: unknown }) => boolean;
+		},
+	) => {
+		return async (...args: unknown[]) => {
+			const key = opts?.getKey?.(...args) ?? String(args[0]);
+			if (guildCache.has(key)) {
+				return guildCache.get(key);
+			}
+			const result = await fn(...args);
+			if (opts?.validate === undefined || opts.validate({ value: result })) {
+				guildCache.set(key, result);
+			}
+			return result;
+		};
+	};
 	(globalThis as Record<string, unknown>).hours = (n: number) => n * 3600;
 	(globalThis as Record<string, unknown>).useApi = () => ({
 		guilds: {
@@ -45,8 +64,14 @@ const { mockGetChannels, mockGuildsGet } = vi.hoisted(() => {
 	});
 	(globalThis as Record<string, unknown>).guildNameToAcronym = (name: string) =>
 		name.slice(0, 2).toUpperCase();
+	(globalThis as Record<string, unknown>).logger = {
+		warn: vi.fn(),
+		info: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	};
 
-	return { mockGetChannels, mockGuildsGet };
+	return { mockGetChannels, mockGuildsGet, guildCache };
 });
 
 vi.mock("@sentry/nuxt", () => ({
@@ -91,6 +116,7 @@ const mockApiGuild = {
 describe("transformGuild", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		guildCache.clear();
 	});
 
 	it("does not call getGuildChannels and returns channels:[] when includeChannels is false", async () => {
@@ -143,5 +169,17 @@ describe("transformGuild", () => {
 		expect(result.manageable).toBe(true);
 		expect(result.channels).toEqual([]);
 		expect(mockGetChannels).not.toHaveBeenCalled();
+	});
+
+	it("falls back to cached guild when live probe fails with a non-404 error", async () => {
+		guildCache.set(`guild:${oauthGuild.id}`, mockApiGuild);
+		mockGuildsGet.mockRejectedValue(
+			Object.assign(new Error("Service unavailable"), { status: 503 }),
+		);
+
+		const result = await transformGuild(userId, oauthGuild, { includeChannels: false });
+
+		expect(result.wolfstarIsIn).toBe(true);
+		expect(mockGuildsGet).toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
### 🔗 Linked issue

resolves #227

### 🧭 Context

After removing WolfStar from a Discord server, the guild could remain on the profile server list with `wolfstarIsIn: true` for up to an hour. Users could still open guild settings because `getGuild` cached positive bot membership responses.

This change probes bot membership live when building the profile guild list and when resolving guilds for settings routes, and invalidates stale guild cache entries when the bot is no longer present.

### 📚 Description

- Add `fetchBotGuildFromDiscord()` as an uncached Discord `guilds.get` probe (404 → bot not in guild)
- Refactor `getGuild` to delegate to the live probe while keeping the existing positive-result cache
- Use the live probe in `transformOauthGuildsAndUser` so profile lists reflect current bot membership
- Use the live probe in `resolveGuildForRequest` and clear cache on 404 so settings routes reject departed guilds
- Invalidate per-guild cache on manual profile refresh (`?refresh=true`)

**Testing:** `pnpm test test/unit/server/utils/discord/` — 32/32 passed
