### PR TITLE
feat(sentry): add Sentry user feedback with custom site design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+<!-- skilld -->
+
+Before modifying code, evaluate each installed skill against the current task.
+For each skill, determine YES/NO relevance and invoke all YES skills before proceeding.
+
+<!-- /skilld -->

--- a/app/components/FeedbackButton.client.vue
+++ b/app/components/FeedbackButton.client.vue
@@ -1,0 +1,18 @@
+<template>
+	<div>
+		<UButton
+			icon="lucide:message-square"
+			color="primary"
+			variant="soft"
+			size="lg"
+			class="rounded-full"
+			aria-label="Send feedback"
+			@click="isOpen = true"
+		/>
+		<FeedbackModal v-model:open="isOpen" />
+	</div>
+</template>
+
+<script setup lang="ts">
+const isOpen = ref(false);
+</script>

--- a/app/components/FeedbackModal.vue
+++ b/app/components/FeedbackModal.vue
@@ -107,7 +107,11 @@ async function onSubmit() {
 			icon: "i-heroicons-check-circle",
 			title: "Feedback Sent",
 		});
-	} catch {
+	} catch (error) {
+		console.error(error);
+		void import("@sentry/nuxt")
+			.then(({ captureException }) => captureException(error))
+			.catch(() => {});
 		toast.add({
 			color: "error",
 			description: "Failed to send feedback. Please try again.",

--- a/app/components/FeedbackModal.vue
+++ b/app/components/FeedbackModal.vue
@@ -49,6 +49,7 @@
 </template>
 
 <script setup lang="ts">
+import { parseError } from "evlog";
 import * as v from "valibot";
 
 const open = defineModel<boolean>("open", { default: false });
@@ -79,6 +80,7 @@ watch(open, (isOpen) => {
 	}
 });
 
+const logger = useLogger("wolfstar:feedback");
 const formRef = useTemplateRef("formRef");
 const isSubmitting = ref(false);
 
@@ -108,7 +110,7 @@ async function onSubmit() {
 			title: "Feedback Sent",
 		});
 	} catch (error) {
-		console.error(error);
+		logger.error("Failed to send feedback", parseError(error));
 		void import("@sentry/nuxt")
 			.then(({ captureException }) => captureException(error))
 			.catch(() => {});

--- a/app/components/FeedbackModal.vue
+++ b/app/components/FeedbackModal.vue
@@ -1,0 +1,121 @@
+<template>
+	<UModal
+		v-model:open="open"
+		title="Send Feedback"
+		description="Report a bug or share your thoughts with the WolfStar team."
+	>
+		<template #body>
+			<UForm ref="formRef" :schema :state class="space-y-4" @submit="onSubmit">
+				<UFormField name="name" label="Name" required>
+					<UInput v-model="state.name" placeholder="Your name" class="w-full" />
+				</UFormField>
+
+				<UFormField name="email" label="Email" required>
+					<UInput
+						v-model="state.email"
+						type="email"
+						placeholder="your@email.com"
+						class="w-full"
+					/>
+				</UFormField>
+
+				<UFormField name="message" label="Message" required>
+					<UTextarea
+						v-model="state.message"
+						placeholder="What happened? What did you expect to happen?"
+						:rows="4"
+						class="w-full"
+					/>
+				</UFormField>
+			</UForm>
+		</template>
+
+		<template #footer>
+			<div class="flex justify-end gap-2">
+				<UButton
+					color="neutral"
+					variant="ghost"
+					:disabled="isSubmitting"
+					@click="open = false"
+				>
+					Cancel
+				</UButton>
+				<UButton color="primary" :loading="isSubmitting" icon="lucide:send" @click="submit">
+					Send Feedback
+				</UButton>
+			</div>
+		</template>
+	</UModal>
+</template>
+
+<script setup lang="ts">
+import * as v from "valibot";
+
+const open = defineModel<boolean>("open", { default: false });
+
+const toast = useToast();
+const { user } = useUserSession();
+
+const schema = v.object({
+	name: v.pipe(v.string(), v.minLength(1, "Name is required")),
+	email: v.pipe(v.string(), v.email("Enter a valid email address")),
+	message: v.pipe(v.string(), v.minLength(10, "Message must be at least 10 characters")),
+});
+
+type FeedbackState = v.InferInput<typeof schema>;
+
+const state = reactive<FeedbackState>({
+	name: user.value?.name ?? "",
+	email: user.value?.email ?? "",
+	message: "",
+});
+
+// Reset state when modal opens so stale data doesn't persist
+watch(open, (isOpen) => {
+	if (isOpen) {
+		state.name = user.value?.name ?? "";
+		state.email = user.value?.email ?? "";
+		state.message = "";
+	}
+});
+
+const formRef = useTemplateRef("formRef");
+const isSubmitting = ref(false);
+
+async function submit() {
+	await formRef.value?.submit();
+}
+
+async function onSubmit() {
+	if (!import.meta.client) return;
+
+	isSubmitting.value = true;
+
+	try {
+		const { captureFeedback } = await import("@sentry/nuxt");
+		captureFeedback({
+			name: state.name,
+			email: state.email,
+			message: state.message,
+		});
+
+		open.value = false;
+
+		toast.add({
+			color: "success",
+			description: "Your feedback has been sent. Thank you!",
+			icon: "i-heroicons-check-circle",
+			title: "Feedback Sent",
+		});
+	} catch {
+		toast.add({
+			color: "error",
+			description: "Failed to send feedback. Please try again.",
+			icon: "i-heroicons-x-circle",
+			title: "Something went wrong",
+		});
+	} finally {
+		isSubmitting.value = false;
+	}
+}
+</script>

--- a/app/components/UserMenu.vue
+++ b/app/components/UserMenu.vue
@@ -1,4 +1,5 @@
 <template>
+	<FeedbackModal v-model:open="isFeedbackOpen" />
 	<UDropdownMenu
 		:items="items"
 		:content="{ align: 'center', collisionPadding: 12 }"
@@ -36,6 +37,7 @@ const { collapsed } = defineProps<{
 	collapsed?: boolean;
 }>();
 
+const isFeedbackOpen = ref(false);
 const colorMode = useColorMode();
 const { user: authUser, clear } = useAuth();
 
@@ -62,6 +64,14 @@ const items = computed<DropdownMenuItem[][]>(() => [
 			icon: "lucide:user",
 			label: "Profile",
 			to: "/profile",
+		},
+		{
+			icon: "lucide:bug",
+			label: "Report a Bug",
+			onSelect(e: Event) {
+				e.preventDefault();
+				isFeedbackOpen.value = true;
+			},
 		},
 	],
 	[

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -15,6 +15,7 @@
 		<ClientOnly>
 			<DeferredMount>
 				<div class="fixed right-4 bottom-4 z-50 flex flex-col space-y-2">
+					<LazyFeedbackButton />
 					<LazyScrollToTopButton />
 				</div>
 			</DeferredMount>


### PR DESCRIPTION
Integrates Sentry's captureFeedback() API behind a custom UI that matches
the project's design system (Nuxt UI + DaisyUI + Valibot), avoiding the
default Sentry widget entirely.

- FeedbackModal.vue: UModal form with name/email/message fields, Valibot
  validation, pre-filled from user session, success/error toasts
- FeedbackButton.client.vue: floating primary button for marketing pages,
  mirrors the ScrollToTopButton pattern in the default layout
- default.vue: adds LazyFeedbackButton to the fixed bottom-right stack
- UserMenu.vue: adds "Report a Bug" item (lucide:bug) to the dropdown

https://claude.ai/code/session_01A4QsYy6VHz7rXhtv22fvMj