### PR TITLE
fix(ui): align feedback and scroll-to-top floating buttons

### DIFF
--- a/app/components/ScrollToTopButton.vue
+++ b/app/components/ScrollToTopButton.vue
@@ -1,14 +1,20 @@
 <template>
-	<UButton
-		aria-label="scroll to top button"
-		:class="{ 'opacity-100': isScrolling, 'opacity-0': !isScrolling }"
-		icon="heroicons-arrow-up"
-		color="neutral"
-		variant="ghost"
-		size="lg"
-		class="rounded-full transition-opacity duration-300"
-		@click="scrollToTop"
-	/>
+	<div
+		class="shrink-0 overflow-hidden transition-[width,opacity,margin] duration-300 ease-in-out"
+		:class="isScrolling ? 'ml-2 w-10 opacity-100' : 'pointer-events-none ml-0 w-0 opacity-0'"
+		:aria-hidden="!isScrolling"
+	>
+		<UButton
+			aria-label="scroll to top button"
+			icon="heroicons-arrow-up"
+			color="neutral"
+			variant="ghost"
+			size="lg"
+			class="rounded-full"
+			:tabindex="isScrolling ? 0 : -1"
+			@click="scrollToTop"
+		/>
+	</div>
 </template>
 
 <script setup lang="ts">

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -14,7 +14,7 @@
 
 		<ClientOnly>
 			<DeferredMount>
-				<div class="fixed right-4 bottom-4 z-50 flex flex-col space-y-2">
+				<div class="fixed right-4 bottom-4 z-50 flex items-center justify-end">
 					<LazyFeedbackButton />
 					<LazyScrollToTopButton />
 				</div>


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

The default layout showed the feedback and scroll-to-top buttons stacked vertically in the bottom-right corner. When the scroll-to-top button was hidden (page at top), it still reserved space via opacity, leaving an awkward gap next to the feedback button.

This change places both controls in a single horizontal row and collapses the scroll button when it is not needed, so the feedback button occupies the same slot without shifting the layout.

### 📚 Description

- Updated `app/layouts/default.vue` to render the floating actions in a horizontal `flex` row aligned to the bottom-right.
- Updated `app/components/ScrollToTopButton.vue` to wrap the button in a collapsing container (`w-0` / `w-10` with opacity and margin transitions) instead of only toggling opacity.
- When the page is not scrolled, the scroll-to-top control is hidden and non-interactive (`pointer-events-none`, `tabindex="-1"`, `aria-hidden`), and feedback stays in the rightmost position.
- When the user scrolls, the scroll-to-top button animates in beside feedback.

**Test plan**
- [x] Verified layout intent in code review
- [ ] Manually confirm on a marketing page: at top of page, only feedback is visible in the bottom-right corner
- [ ] Scroll down and confirm scroll-to-top appears beside feedback with a smooth transition
- [ ] Scroll back to top and confirm scroll-to-top collapses and feedback returns to the rightmost slot
