### PR TITLE
fix(sentry): delete client source maps after upload to prevent public exposure

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -524,6 +524,12 @@ export default defineNuxtConfig({
 	sentry: {
 		...runtimeConfig.sentry,
 		autoInjectServerSentry: "top-level-import",
+		sourcemaps: {
+			filesToDeleteAfterUpload: [
+				".*/**/public/**/*.map",
+				".output/**/public/**/*.map",
+			],
+		},
 	},
 
 	seo: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -525,10 +525,7 @@ export default defineNuxtConfig({
 		...runtimeConfig.sentry,
 		autoInjectServerSentry: "top-level-import",
 		sourcemaps: {
-			filesToDeleteAfterUpload: [
-				".*/**/public/**/*.map",
-				".output/**/public/**/*.map",
-			],
+			filesToDeleteAfterUpload: [".*/**/public/**/*.map", ".output/**/public/**/*.map"],
 		},
 	},
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds the missing `filesToDeleteAfterUpload` option to the `sentry.sourcemaps` configuration in `nuxt.config.ts`.

## Why

The project already enables client-side source maps via:

```ts
sourcemap: { client: "hidden" },
```

However, the `sentry` module config was missing `filesToDeleteAfterUpload`. Without it, the generated `.js.map` files remain in the build output (`.output/public/`) after being uploaded to Sentry. Those files can be served publicly, leaking the application's original source code.

The [Sentry Nuxt sourcemaps docs](https://docs.sentry.io/platforms/javascript/guides/nuxt/sourcemaps/) explicitly warn:

> Generating source maps may expose them to the public, potentially causing your source code to be leaked. You can prevent this by configuring your server to deny access to `.js.map` files, or by using Sentry Vite Plugin's `sourcemaps.filesToDeleteAfterUpload` option to delete source maps after they've been uploaded to Sentry.

## Change

```ts
sentry: {
  ...runtimeConfig.sentry,
  autoInjectServerSentry: "top-level-import",
  sourcemaps: {
    filesToDeleteAfterUpload: [
      ".*/**/public/**/*.map",
      ".output/**/public/**/*.map",
    ],
  },
},
```

The two glob patterns cover:
- `.*/**/public/**/*.map` — hidden-directory variants (e.g. `.netlify/`)
- `.output/**/public/**/*.map` — Nuxt's standard production output directory

These are the exact patterns recommended by the official Sentry docs for a Nuxt deployment.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-363ae77f-aedb-41c5-95e3-15715a45c70f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-363ae77f-aedb-41c5-95e3-15715a45c70f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

