### PR TITLE
feat: add session refresh on app mount and document visibility

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -15,6 +15,8 @@
 </template>
 
 <script setup lang="ts">
+useSessionRefresh();
+
 const router = useRouter();
 const appName = ref<"wolfstar" | "staryl">("wolfstar");
 

--- a/app/composables/use-session-refresh.ts
+++ b/app/composables/use-session-refresh.ts
@@ -1,0 +1,21 @@
+export function useSessionRefresh() {
+	const { fetch: refetchSession } = useUserSession();
+	const documentVisibility = useDocumentVisibility();
+
+	async function refreshAndSync(): Promise<void> {
+		await $fetch("/api/auth/refresh").catch(() => {});
+		await refetchSession();
+	}
+
+	onMounted(() => {
+		if (import.meta.test) return;
+		void refreshAndSync();
+	});
+
+	if (import.meta.client) {
+		watch(documentVisibility, (visibility) => {
+			if (visibility !== "visible" || import.meta.test) return;
+			void refreshAndSync();
+		});
+	}
+}

--- a/test/nuxt/composables/use-session-refresh.spec.ts
+++ b/test/nuxt/composables/use-session-refresh.spec.ts
@@ -1,0 +1,28 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { describe, expect, it, vi } from "vitest";
+import { defineComponent } from "vue";
+
+describe("useSessionRefresh", () => {
+	async function setup() {
+		const TestComponent = defineComponent({
+			setup() {
+				useSessionRefresh();
+				return () => null;
+			},
+		});
+
+		return mountSuspended(TestComponent);
+	}
+
+	it("should mount without errors", async () => {
+		await expect(setup()).resolves.toBeDefined();
+	});
+
+	it("should not call $fetch during test environment (import.meta.test guard)", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		await setup();
+		// The import.meta.test guard in onMounted prevents any $fetch calls
+		expect(fetchSpy).not.toHaveBeenCalledWith("/api/auth/refresh", expect.anything());
+		fetchSpy.mockRestore();
+	});
+});


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please reference the issue number if applicable -->

### 🧭 Context

This change adds automatic session refresh functionality to ensure the user's authentication state stays synchronized with the server. The session is refreshed when the app mounts and whenever the document becomes visible (e.g., when returning from another tab).

### 📚 Description

Added a new `useSessionRefresh()` composable that:

- Calls the `/api/auth/refresh` endpoint and refetches the user session on app mount
- Watches document visibility and refreshes the session when the user returns to the tab
- Gracefully handles refresh failures without throwing errors
- Skips refresh logic during tests to avoid side effects

The composable is integrated into `app.vue` to ensure it runs for all routes and pages.

**Why this is needed:**
- Keeps the user's session fresh and prevents unexpected logouts
- Handles cases where the session may have expired while the user was away
- Improves user experience by maintaining authentication state across tab switches

**Implementation details:**
- Uses `useDocumentVisibility()` to detect when the document becomes visible
- Silently catches refresh errors to prevent disrupting the app
- Respects `import.meta.test` to avoid running during tests
- Client-side only (guarded by `import.meta.client`)

https://claude.ai/code/session_017WBTyhDrdJzxj7WY2Gsv1C