### PR TITLE
feat(auth): make session cookie name configurable per deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ NUXT_OAUTH_DISCORD_BOT_TOKEN=
 # You can use: openssl rand -base64 32
 NUXT_SESSION_PASSWORD=
 
+# Session cookie name — MUST differ per deployment to prevent cookie bleed across subdomains
+# Production (wolfstar.rocks):  leave blank (defaults to wolfstar-session)
+# Beta/staging (beta.wolfstar.rocks): wolfstar-session-beta
+NUXT_SESSION_COOKIE_NAME=
+
 # Secret for generating OG images (generate a secure random string)
 # You can use: openssl rand -base64 32
 NUXT_IMAGE_PROXY_SECRET=

--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -48,6 +48,7 @@ jobs:
             pwa
             sentry
             seo
+            session
             test
             ui
           subjectPattern: ^(?![A-Z]).+$

--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -48,7 +48,6 @@ jobs:
             pwa
             sentry
             seo
-            session
             test
             ui
           subjectPattern: ^(?![A-Z]).+$

--- a/server/utils/runtimeConfig.ts
+++ b/server/utils/runtimeConfig.ts
@@ -34,7 +34,7 @@ export function generateRuntimeConfig() {
 		},
 		session: {
 			maxAge: 60 * 60 * 24 * 7, // 1 week
-			name: "wolfstar-session",
+			name: process.env.NUXT_SESSION_COOKIE_NAME ?? "wolfstar-session",
 			password: process.env.NUXT_SESSION_PASSWORD ?? "",
 			cookie: {
 				sameSite: "strict" as "lax" | "strict" | "none",

--- a/server/utils/runtimeConfig.ts
+++ b/server/utils/runtimeConfig.ts
@@ -34,7 +34,7 @@ export function generateRuntimeConfig() {
 		},
 		session: {
 			maxAge: 60 * 60 * 24 * 7, // 1 week
-			name: process.env.NUXT_SESSION_COOKIE_NAME ?? "wolfstar-session",
+			name: process.env.NUXT_SESSION_COOKIE_NAME || "wolfstar-session",
 			password: process.env.NUXT_SESSION_PASSWORD ?? "",
 			cookie: {
 				sameSite: "strict" as "lax" | "strict" | "none",


### PR DESCRIPTION
Add NUXT_SESSION_COOKIE_NAME env var so beta.wolfstar.rocks can use a
distinct cookie name (e.g. wolfstar-session-beta) instead of sharing
the same name as production, preventing operational confusion and
guarding against accidental parent-domain cookie bleed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NGwMeuauwcQmbcRuXt8YRY

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the session cookie name configurable via `NUXT_SESSION_COOKIE_NAME`, enabling beta deployments to use a distinct cookie (e.g. `wolfstar-session-beta`) instead of sharing the production `wolfstar-session` name and risking parent-domain cookie bleed.

- **`server/utils/runtimeConfig.ts`**: Replaces the hardcoded `"wolfstar-session"` with `process.env.NUXT_SESSION_COOKIE_NAME || "wolfstar-session"`, using `||` so that an empty-string env var (the documented production pattern) correctly falls through to the default.
- **`.env.example`**: Adds documentation for the new variable, clearly marking production as "leave blank" and beta as `wolfstar-session-beta`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line env-var read with a correct `||` fallback and matching documentation in `.env.example`.

The only changed logic is the cookie name source: previously hardcoded, now `process.env.NUXT_SESSION_COOKIE_NAME || "wolfstar-session"`. Using `||` (not `??`) ensures an empty-string env var — the documented production default — still resolves to the intended fallback. The pattern is consistent with how every other env var in `generateRuntimeConfig()` is handled, and `nuxt.config.ts` already uses this function for its `runtimeConfig` object.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/utils/runtimeConfig.ts | Session cookie name now reads from `NUXT_SESSION_COOKIE_NAME || "wolfstar-session"`. The `||` operator correctly handles empty-string values, consistent with the rest of the file's env-var reading pattern. |
| .env.example | Documents new `NUXT_SESSION_COOKIE_NAME` variable with clear per-deployment guidance; leave blank for production, set to `wolfstar-session-beta` for beta. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[nuxt.config.ts at build time] --> B[generateRuntimeConfig]
    B --> C{NUXT_SESSION_COOKIE_NAME set and non-empty?}
    C -- Yes --> D[Use env var value\ne.g. wolfstar-session-beta]
    C -- No / empty string --> E[Fall back to\nwolfstar-session]
    D --> F[runtimeConfig.session.name]
    E --> F
    F --> G[nuxt-auth-utils\nsession middleware]
    G --> H[Set-Cookie: wolfstar-session-beta\nor wolfstar-session]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[nuxt.config.ts at build time] --> B[generateRuntimeConfig]
    B --> C{NUXT_SESSION_COOKIE_NAME set and non-empty?}
    C -- Yes --> D[Use env var value\ne.g. wolfstar-session-beta]
    C -- No / empty string --> E[Fall back to\nwolfstar-session]
    D --> F[runtimeConfig.session.name]
    E --> F
    F --> G[nuxt-auth-utils\nsession middleware]
    G --> H[Set-Cookie: wolfstar-session-beta\nor wolfstar-session]
```

</a>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into claude/cookie-i..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/86c6b986a47826be71d8e89e2b11c022c021ec69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40283030)</sub>

<!-- /greptile_comment -->