### PR TITLE
ci: block compromised npm packages with Socket Firewall Free

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -26,10 +26,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🔠 Fix lint errors
         run: vp run lint:fix

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,16 +27,17 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
-
-      - name: 🟧 Install pnpm globally
-        run: vp install -g pnpm
+          sfw: true
 
       - name: 🧪 Run Chromatic Visual and Accessibility Tests
         uses: chromaui/action@f191a0224b10e1a38b2091cefb7b7a2337009116 # v16.0.0
+        with:
+          buildCommand: vp run build-storybook
+          outputDir: storybook-static
         env:
           CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
           CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
-          run-install: false
-
-      - name: 📦 Install dependencies (root only, no scripts)
-        run: vp install --filter . --ignore-scripts
+          sfw: true
+          # root only, no scripts
+          run-install: |
+            - args: ['--filter', '.', '--ignore-scripts']
 
       - name: 🔠 Lint project
         run: vp run lint
@@ -50,10 +50,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🧪 Unit tests
         run: vp test --project unit --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml
@@ -88,10 +89,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🌐 Install browser
         run: vp exec playwright install --with-deps chromium-headless-shell
@@ -133,10 +135,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🔼 Generate Prisma Client
         run: vp run prisma:generate
@@ -171,10 +174,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: ⚡ Run benchmarks
         uses: CodSpeedHQ/action@4deb3275dd364fb96fb074c953133d29ec96f80f # v4.10.6
@@ -194,10 +198,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🔼 Generate Prisma Client
         run: vp run prisma:generate
@@ -222,10 +227,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🔼 Generate Prisma Client
         run: vp run prisma:generate
@@ -249,10 +255,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           cache: true
+          sfw: true
 
       - name: 🧹 Check for unused code
         run: vp run knip

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           run-install: false

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
           node-version: lts/*
           run-install: false
@@ -66,7 +66,11 @@ jobs:
 
       - name: 📦 Install dependencies
         if: steps.check.outputs.skip == 'false'
-        run: vp install --filter . --ignore-scripts
+        uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
+        with:
+          sfw: true
+          run-install: |
+            - args: ['--filter', '.', '--ignore-scripts']
 
       - name: 📝 Generate release notes
         if: steps.check.outputs.skip == 'false'

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -64,6 +64,11 @@ jobs:
           git tag -a "$VERSION" -m "Release $VERSION"
           git push origin "$VERSION"
 
+      # setup-vp runs twice in this job by design: the first call (run-install: false)
+      # only provisions the toolchain so the version/tag steps can run, and this second
+      # call performs the sfw-guarded dependency install, gated on a new tag actually
+      # being created. node-version is inherited from the first call (both default to
+      # the latest LTS).
       - name: 📦 Install dependencies
         if: steps.check.outputs.skip == 'false'
         uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0


### PR DESCRIPTION
## Context

Replicates [npmx-dev/npmx.dev#2889](https://github.com/npmx-dev/npmx.dev/pull/2889) on this codebase.

The npm ecosystem has been hit repeatedly by supply-chain attacks. [Socket Firewall Free](https://docs.socket.dev/docs/socket-firewall-free) (`sfw`) blocks known-malicious package versions at download time, failing the install before anything is written or any lifecycle/postinstall script runs. Socket typically flags these packages within ~5 minutes of publish, which covers the ~3-36 hour window before npm unpublishes them. It is free, with no licence, account, or attribution required.

`voidzero-dev/setup-vp` gained built-in support for this in v1.12.0 ([setup-vp#72](https://github.com/voidzero-dev/setup-vp/pull/72)), so opting in is just `sfw: true`.

## Changes

Bump `voidzero-dev/setup-vp` from v1.10.0 to v1.12.0 across all workflows and enable `sfw: true` on every job that installs dependencies.

- **`ci.yml`**: add `sfw: true` to `unit`, `test`, `browser`, `benchmark`, `a11y`, `perf`, and `knip`; convert the `lint` job's separate `vp install --filter . --ignore-scripts` step into setup-vp's `run-install` config so the install is guarded by sfw.
- **`autofix.yml`**: bump + `sfw: true`.
- **`chromatic.yml`**: bump + `sfw: true`; drop the global `vp install -g pnpm` step and pass `buildCommand: vp run build-storybook` / `outputDir: storybook-static` to `chromaui/action` directly, so it no longer needs to detect the package manager (`storybook-static` is already in `.gitignore`).
- **`release-tag.yml`**: install dependencies through setup-vp's `run-install` with `sfw: true` instead of a bare `vp install`.
- **`release-pr.yml`**: version bump only (this workflow has no install step).

## Notes on differences from the source PR

The npmx PR also touched `deploy-canary.yml` (adds `SocketDev/action`) and `lunaria.yml`, plus a `.github/zizmor.yml` line-reference tied to lunaria. This repo has neither workflow, and our `.github/zizmor.yml` has no `stale-action-refs` entry, so those parts don't apply here.

The pinned v1.12.0 SHA (`2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1`) was verified against the upstream `v1.12.0` tag. All edited workflow files were validated as parseable YAML.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Workflow trigger] --> B[actions/checkout]
    B --> C[voidzero-dev/setup-vp v1.12.0]
    C --> D{run-install?}
    D -->|false| E[Toolchain only\nNo packages installed]
    D -->|default / config| F[Activate sfw interceptor]
    F --> G[Run package install\nvp install with args]
    G --> H{Package flagged\nby Socket?}
    H -->|Yes - known malicious| I[❌ Install fails\nWorkflow blocked]
    H -->|No| J[✅ Packages installed\nWorkflow continues]
    E --> K[Downstream steps\ne.g. version/tag in release-tag.yml]
    K --> L[Second setup-vp call\nwith sfw:true]
    L --> F

    style I fill:#ff4444,color:#fff
    style J fill:#44bb44,color:#fff
    style F fill:#ff8800,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Workflow trigger] --> B[actions/checkout]
    B --> C[voidzero-dev/setup-vp v1.12.0]
    C --> D{run-install?}
    D -->|false| E[Toolchain only\nNo packages installed]
    D -->|default / config| F[Activate sfw interceptor]
    F --> G[Run package install\nvp install with args]
    G --> H{Package flagged\nby Socket?}
    H -->|Yes - known malicious| I[❌ Install fails\nWorkflow blocked]
    H -->|No| J[✅ Packages installed\nWorkflow continues]
    E --> K[Downstream steps\ne.g. version/tag in release-tag.yml]
    K --> L[Second setup-vp call\nwith sfw:true]
    L --> F

    style I fill:#ff4444,color:#fff
    style J fill:#44bb44,color:#fff
    style F fill:#ff8800,color:#fff
```

</a>

<sub>Reviews (2): Last reviewed commit: ["ci: document two-step setup-vp pattern i..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/f6ac8fb788e2863f24253b61e9b5e17fcd939b34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40354185)</sub>

<!-- /greptile_comment -->