### PR TITLE
fix(security): disable nuxt-security corsHandler to unblock prerender

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -516,6 +516,14 @@ export default defineNuxtConfig({
 				fullscreen: "*",
 			},
 		},
+		// Disabled because the runtime CORS middleware imports `handleCors` from h3 v2
+		// (pulled in by Nuxt 4.4.x), while Nitro's prerenderer dispatches events using
+		// h3 v1 (plain-object headers). During `nuxt build` the crawler triggers
+		// `isPreflightRequest`, which calls `event.req.headers.get()` on the v1 event and
+		// crashes every prerendered route. The default `origin` is the site's own URL, so
+		// CORS here only ever allowed same-origin requests — dropping it is a no-op for the
+		// same-origin dashboard while restoring a working prerender/build.
+		corsHandler: false,
 		rateLimiter: false,
 		sri: false,
 		ssg: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -516,14 +516,6 @@ export default defineNuxtConfig({
 				fullscreen: "*",
 			},
 		},
-		// Disabled because the runtime CORS middleware imports `handleCors` from h3 v2
-		// (pulled in by Nuxt 4.4.x), while Nitro's prerenderer dispatches events using
-		// h3 v1 (plain-object headers). During `nuxt build` the crawler triggers
-		// `isPreflightRequest`, which calls `event.req.headers.get()` on the v1 event and
-		// crashes every prerendered route. The default `origin` is the site's own URL, so
-		// CORS here only ever allowed same-origin requests — dropping it is a no-op for the
-		// same-origin dashboard while restoring a working prerender/build.
-		corsHandler: false,
 		rateLimiter: false,
 		sri: false,
 		ssg: {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"nuxt": "^4.4.2",
 		"nuxt-auth-utils": "^0.5.29",
 		"nuxt-og-image": "6.5.3",
-		"nuxt-security": "^2.5.1",
+		"nuxt-security": "^2.6.0",
 		"nuxt-vitalizer": "^2.0.0",
 		"postcss-nested": "^7.0.2",
 		"rou3": "^0.8.0",

--- a/patches/nuxt-security.patch
+++ b/patches/nuxt-security.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/runtime/server/middleware/corsHandler.js b/dist/runtime/server/middleware/corsHandler.js
+--- a/dist/runtime/server/middleware/corsHandler.js
++++ b/dist/runtime/server/middleware/corsHandler.js
+@@ -1,6 +1,9 @@
+ import { defineEventHandler, handleCors } from "h3";
+ import { resolveSecurityRules } from "../../nitro/context/index.js";
+ export default defineEventHandler((event) => {
++  if (import.meta.prerender) {
++    return;
++  }
+   const rules = resolveSecurityRules(event);
+   if (rules.enabled && rules.corsHandler) {
+     const { corsHandler } = rules;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ overrides:
 
 patchedDependencies:
   '@nuxt/test-utils': 8438d6588e19230d3392ce53e45dd8e9bff54eaa3ce18092602fefd40c2eefe9
+  nuxt-security: ad8aa26b56f2580c29f127516536e82283fa25fab17c7cf9c5ec115374969e1b
 
 importers:
 
@@ -146,8 +147,8 @@ importers:
         specifier: 6.5.3
         version: 6.5.3(@nuxt/schema@4.4.8)(@takumi-rs/core@1.1.2)(@takumi-rs/wasm@1.1.2)(@unhead/vue@2.1.15)(@voidzero-dev/vite-plus-core@0.1.19)(esbuild@0.28.1)(fontless@0.2.1)(nitropack@2.13.4)(nuxt@4.4.8)(playwright-core@1.60.0)(rolldown@1.0.1)(rollup@4.62.2)(sharp@0.34.5)(tailwindcss@4.2.2)(unifont@0.7.4)(unstorage@1.17.5)(vue@3.5.39)(zod@4.3.6)
       nuxt-security:
-        specifier: ^2.5.1
-        version: 2.5.1(magicast@0.5.3)(rollup@4.62.2)
+        specifier: ^2.6.0
+        version: 2.6.0(patch_hash=ad8aa26b56f2580c29f127516536e82283fa25fab17c7cf9c5ec115374969e1b)(magicast@0.5.3)(rollup@4.62.2)
       nuxt-vitalizer:
         specifier: ^2.0.0
         version: 2.0.0(magicast@0.5.3)
@@ -540,10 +541,6 @@ packages:
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@7.29.7':
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
@@ -580,10 +577,6 @@ packages:
     resolution: {integrity: sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
@@ -672,11 +665,6 @@ packages:
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.3':
-    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
@@ -1097,10 +1085,6 @@ packages:
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.7':
@@ -10517,9 +10501,9 @@ packages:
       zod:
         optional: true
 
-  nuxt-security@2.5.1:
-    resolution: {integrity: sha512-gXUhJiOqgkKkP0FHDAPOuREjoala0p6G/4TIlkti1ZafpJV8TkjjFqCNT6NuiWHxKzVYY00OIR1tbRcZuJ7LmQ==}
-    engines: {node: '>=20.0.0'}
+  nuxt-security@2.6.0:
+    resolution: {integrity: sha512-5rEfyxw1gS+vl1s5q7GcGuFOL5g0I03Q/mz7Zfr+IRJFsaZKwRxNVMFNRbatfK3Dz65LuRPnLewLmJ+Yh9ujOA==}
+    engines: {node: '>=24.0.0'}
 
   nuxt-seo-utils@8.1.9:
     resolution: {integrity: sha512-IoVPkJU8kSSroCaUemvBX4Oksc1d3cyTMiInRv5wqjF6uzwprS6Oc9ucmcX/9brI68UBb3sIrhXPLrGZ2zKCFA==}
@@ -14076,13 +14060,13 @@ snapshots:
   '@babel/core@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -14112,14 +14096,6 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/generator@7.29.1':
-    dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.7
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
 
   '@babel/generator@7.29.7':
     dependencies:
@@ -14189,8 +14165,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-globals@7.28.0': {}
-
   '@babel/helper-globals@7.29.7': {}
 
   '@babel/helper-member-expression-to-functions@7.29.7':
@@ -14219,7 +14193,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -14285,16 +14259,12 @@ snapshots:
 
   '@babel/helpers@7.29.2':
     dependencies:
-      '@babel/template': 7.28.6
+      '@babel/template': 7.29.7
       '@babel/types': 7.29.7
 
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-
-  '@babel/parser@7.29.3':
-    dependencies:
       '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
@@ -14362,22 +14332,10 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
 
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -14833,18 +14791,6 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
-
-  '@babel/traverse@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.3
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.7
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.29.7':
     dependencies:
@@ -16752,7 +16698,7 @@ snapshots:
       vue-bundle-renderer: 2.3.1
       vue-devtools-stub: 0.1.0
     optionalDependencies:
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -17100,7 +17046,7 @@ snapshots:
       vue: 3.5.39(typescript@6.0.2)
       vue-bundle-renderer: 2.3.1
     optionalDependencies:
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
       rolldown: 1.0.1
       rollup-plugin-visualizer: 7.0.1(rolldown@1.0.1)(rollup@4.62.2)
     transitivePeerDependencies:
@@ -25334,9 +25280,9 @@ snapshots:
       - yjs
       - yup
 
-  nuxt-security@2.5.1(magicast@0.5.3)(rollup@4.62.2):
+  nuxt-security@2.6.0(patch_hash=ad8aa26b56f2580c29f127516536e82283fa25fab17c7cf9c5ec115374969e1b)(magicast@0.5.3)(rollup@4.62.2):
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.3)
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
       basic-auth: 2.0.1
       defu: 6.1.7
       nuxt-csurf: 1.6.5(magicast@0.5.3)
@@ -28679,11 +28625,11 @@ snapshots:
 
   unplugin-remove@1.0.3(rollup@4.62.2):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
-      '@babel/traverse': 7.29.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       magic-string: 0.30.21
       unplugin: 1.16.1
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ overrides:
 
 patchedDependencies:
     "@nuxt/test-utils": patches/@nuxt__test-utils.patch
+    "nuxt-security": patches/nuxt-security.patch
 
 catalogs:
     msw:


### PR DESCRIPTION
Nuxt 4.4.x pulls in h3 v2, so nuxt-security's CORS middleware imports
`handleCors` from h3 v2. Nitro's prerenderer, however, dispatches events
using h3 v1 (plain-object headers). During `nuxt build` the prerender
crawler triggers `isPreflightRequest`, which calls `event.req.headers.get()`
on the v1 event and throws `event.req.headers.get is not a function`,
failing every prerendered route (/, /commands, /privacy, /staryl, /terms,
/wolfstar, /sitemap.xml, ...).

The default corsHandler `origin` is the site's own URL, so it only ever
allowed same-origin requests — dropping it is a no-op for the same-origin
dashboard while restoring a working build/prerender.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UBmrZThUSRxtdNHEUmXrxN

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant NuxtBuild as nuxt build
    participant Nitro as Nitro Prerenderer
    participant CorsHandler as corsHandler.js (patched)
    participant H3v1 as h3 v1 Event (prerender)
    participant H3v2 as h3 v2 handleCors

    NuxtBuild->>Nitro: start prerender crawler
    Nitro->>CorsHandler: dispatch event (h3 v1)
    CorsHandler->>CorsHandler: check import.meta.prerender → true
    CorsHandler-->>Nitro: return early (no CORS processing)
    Note over CorsHandler,H3v1: h3 v1 event never passed to handleCors — avoids headers.get() TypeError

    Note over NuxtBuild,H3v2: At runtime (production serving)
    NuxtBuild->>Nitro: real HTTP request
    Nitro->>CorsHandler: dispatch event (h3 v2)
    CorsHandler->>CorsHandler: import.meta.prerender → false
    CorsHandler->>H3v2: resolveSecurityRules + handleCors
    H3v2-->>Nitro: CORS headers applied normally
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant NuxtBuild as nuxt build
    participant Nitro as Nitro Prerenderer
    participant CorsHandler as corsHandler.js (patched)
    participant H3v1 as h3 v1 Event (prerender)
    participant H3v2 as h3 v2 handleCors

    NuxtBuild->>Nitro: start prerender crawler
    Nitro->>CorsHandler: dispatch event (h3 v1)
    CorsHandler->>CorsHandler: check import.meta.prerender → true
    CorsHandler-->>Nitro: return early (no CORS processing)
    Note over CorsHandler,H3v1: h3 v1 event never passed to handleCors — avoids headers.get() TypeError

    Note over NuxtBuild,H3v2: At runtime (production serving)
    NuxtBuild->>Nitro: real HTTP request
    Nitro->>CorsHandler: dispatch event (h3 v2)
    CorsHandler->>CorsHandler: import.meta.prerender → false
    CorsHandler->>H3v2: resolveSecurityRules + handleCors
    H3v2-->>Nitro: CORS headers applied normally
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apatches%2Fnuxt-security.patch%3A8-10%0A**No%20upstream%20reference%20in%20the%20patch**%0A%0AThe%20patch%20file%20contains%20no%20comment%20linking%20to%20the%20nuxt-security%20upstream%20issue%20or%20the%20%60h3%60%20v1%2Fv2%20incompatibility%20bug%20report.%20Without%20that%20reference%2C%20future%20maintainers%20have%20no%20signal%20for%20when%20this%20patch%20is%20safe%20to%20remove%2C%20and%20a%20routine%20%60nuxt-security%60%20minor%20bump%20could%20silently%20re-apply%20a%20now-stale%20patch%20offset%20if%20the%20surrounding%20code%20shifts.%0A%0A&repo=wolfstar-project%2Fwolfstar.rocks&pr=255&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apatches%2Fnuxt-security.patch%3A8-10%0A**No%20upstream%20reference%20in%20the%20patch**%0A%0AThe%20patch%20file%20contains%20no%20comment%20linking%20to%20the%20nuxt-security%20upstream%20issue%20or%20the%20%60h3%60%20v1%2Fv2%20incompatibility%20bug%20report.%20Without%20that%20reference%2C%20future%20maintainers%20have%20no%20signal%20for%20when%20this%20patch%20is%20safe%20to%20remove%2C%20and%20a%20routine%20%60nuxt-security%60%20minor%20bump%20could%20silently%20re-apply%20a%20now-stale%20patch%20offset%20if%20the%20surrounding%20code%20shifts.%0A%0A&pr=255&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22wolfstar-project%2Fwolfstar.rocks%22%20on%20the%20existing%20branch%20%22claude%2Fprerender-header-compat-23ltkc%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fprerender-header-compat-23ltkc%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apatches%2Fnuxt-security.patch%3A8-10%0A**No%20upstream%20reference%20in%20the%20patch**%0A%0AThe%20patch%20file%20contains%20no%20comment%20linking%20to%20the%20nuxt-security%20upstream%20issue%20or%20the%20%60h3%60%20v1%2Fv2%20incompatibility%20bug%20report.%20Without%20that%20reference%2C%20future%20maintainers%20have%20no%20signal%20for%20when%20this%20patch%20is%20safe%20to%20remove%2C%20and%20a%20routine%20%60nuxt-security%60%20minor%20bump%20could%20silently%20re-apply%20a%20now-stale%20patch%20offset%20if%20the%20surrounding%20code%20shifts.%0A%0A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.&repo=wolfstar-project%2Fwolfstar.rocks&uid=108079&ts=1782648351&sig=1e00313544ab7990b65f817b8df0d507a63d997987e11955f3b16d53dac144bc&pr=255&platform=github&fid=b7208bac-8bf2-4391-abb6-756417efc628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=3"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
patches/nuxt-security.patch:8-10
**No upstream reference in the patch**

The patch file contains no comment linking to the nuxt-security upstream issue or the `h3` v1/v2 incompatibility bug report. Without that reference, future maintainers have no signal for when this patch is safe to remove, and a routine `nuxt-security` minor bump could silently re-apply a now-stale patch offset if the surrounding code shifts.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): patch nuxt-security corsH..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/14d77196aeab1d69d4b575a8149be863cbd2168e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40358494)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->