### PR TITLE
test(a11y): consolidate app component accessibility audits into a11y.spec

### DIFF
--- a/test/nuxt/a11y.spec.ts
+++ b/test/nuxt/a11y.spec.ts
@@ -1,5 +1,3 @@
-import { mountSuspended } from "@nuxt/test-utils/runtime";
-import { describe, expect, it } from "vitest";
 import {
 	AppFooter,
 	AppHeader,
@@ -17,6 +15,8 @@ import {
 	IconsWolfstar,
 	Separator,
 } from "#components";
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { describe, expect, it } from "vitest";
 import { runAxe } from "./utils/axe";
 
 // Stub used when auditing AppHeader so the header doesn't depend on the lazy auth

--- a/test/nuxt/a11y.spec.ts
+++ b/test/nuxt/a11y.spec.ts
@@ -1,63 +1,10 @@
-import type { VueWrapper } from "@vue/test-utils";
-import type { AxeResults, RunOptions } from "axe-core";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import { afterEach, describe, expect, it } from "vitest";
-import "axe-core";
-
-// axe-core is a UMD module that exposes itself as window.axe in the browser
-declare const axe: {
-	run: (context: Element, options?: RunOptions) => Promise<AxeResults>;
-};
-
-// Track mounted containers for cleanup
-const mountedContainers: HTMLElement[] = [];
-
-const axeRunOptions: RunOptions = {
-	// Only compute violations to reduce work per run
-	resultTypes: ["violations"],
-	// Disable rules that don't apply to isolated component testing
-	rules: {
-		// These rules check page-level concerns that don't apply to isolated components
-		"landmark-one-main": { enabled: false },
-		"region": { enabled: false },
-		"page-has-heading-one": { enabled: false },
-		// Duplicate landmarks are expected when testing multiple header/footer components
-		"landmark-no-duplicate-banner": { enabled: false },
-		"landmark-no-duplicate-contentinfo": { enabled: false },
-		"landmark-no-duplicate-main": { enabled: false },
-		// Color contrast checks are unreliable in isolated component tests because
-		// DaisyUI/Tailwind theme variables resolve differently without the full page
-		// context (data-theme attribute on <html>). Contrast should be validated via
-		// full-page Lighthouse or manual audits instead.
-		"color-contrast": { enabled: false },
-	},
-};
-
-/**
- * Run axe accessibility audit on a mounted component.
- * Mounts the component in an isolated container to avoid cross-test pollution.
- */
-async function runAxe(wrapper: VueWrapper): Promise<AxeResults> {
-	const container = document.createElement("div");
-	container.id = `test-container-${Date.now()}`;
-	document.body.appendChild(container);
-	mountedContainers.push(container);
-
-	const el = wrapper.element.cloneNode(true) as HTMLElement;
-	container.appendChild(el);
-
-	return axe.run(container, axeRunOptions);
-}
-
-// Clean up mounted containers after each test
-afterEach(() => {
-	for (const container of mountedContainers) {
-		container.remove();
-	}
-	mountedContainers.length = 0;
-});
-
+import { describe, expect, it } from "vitest";
 import {
+	AppFooter,
+	AppHeader,
+	AppHeaderAuth,
+	AppLogoMark,
 	DiscordEmbed,
 	DiscordInvite,
 	DiscordMention,
@@ -70,6 +17,21 @@ import {
 	IconsWolfstar,
 	Separator,
 } from "#components";
+import { runAxe } from "./utils/axe";
+
+// Stub used when auditing AppHeader so the header doesn't depend on the lazy auth
+// dropdown's async session fetch. The stub keeps an accessible name so it doesn't
+// introduce its own violations; AppHeaderAuth is audited separately with the real
+// component below.
+const SignInStub = {
+	template: `<button type="button" aria-label="Sign in with Discord">Sign in</button>`,
+};
+
+function mountAppHeader() {
+	return mountSuspended(AppHeader, {
+		global: { stubs: { AppHeaderAuth: SignInStub, LazyAppHeaderAuth: SignInStub } },
+	});
+}
 
 describe("component accessibility audits", () => {
 	describe("Discord components", () => {
@@ -269,6 +231,96 @@ describe("component accessibility audits", () => {
 			const component = await mountSuspended(IconsWolfstar);
 			const results = await runAxe(component);
 			expect(results.violations).toEqual([]);
+		});
+	});
+
+	describe("AppFooter", () => {
+		it("has no axe-core violations", async () => {
+			const wrapper = await mountSuspended(AppFooter);
+			const results = await runAxe(wrapper);
+			expect(results.violations).toEqual([]);
+		});
+
+		it("exposes the footer landmark with an accessible name", async () => {
+			const wrapper = await mountSuspended(AppFooter);
+			expect(wrapper.find("[aria-label='Site footer']").exists()).toBe(true);
+		});
+
+		it("marks the decorative logo as an image and hides the inner svg from AT", async () => {
+			const wrapper = await mountSuspended(AppFooter);
+			const logo = wrapper.find("[role='img'][aria-label='WolfStar logo']");
+			expect(logo.exists()).toBe(true);
+			expect(logo.find("svg").attributes("aria-hidden")).toBe("true");
+		});
+
+		it("gives the external links accessible names that announce a new tab", async () => {
+			const wrapper = await mountSuspended(AppFooter);
+			expect(
+				wrapper.find("[aria-label='Powered by Netlify - opens in new tab']").exists(),
+			).toBe(true);
+			expect(
+				wrapper.find("[aria-label='Visit WolfStar on GitHub - opens in new tab']").exists(),
+			).toBe(true);
+		});
+	});
+
+	describe("AppHeader", () => {
+		it("has no axe-core violations", async () => {
+			const wrapper = await mountAppHeader();
+			const results = await runAxe(wrapper);
+			expect(results.violations).toEqual([]);
+		});
+
+		it("renders the banner landmark", async () => {
+			const wrapper = await mountAppHeader();
+			expect(wrapper.find("header").exists()).toBe(true);
+		});
+
+		it("names the primary navigation for assistive tech", async () => {
+			const wrapper = await mountAppHeader();
+			expect(wrapper.find("[aria-label='Main navigation']").exists()).toBe(true);
+		});
+
+		it("renders the WolfStar logo mark with the resized svg hidden from AT", async () => {
+			const wrapper = await mountAppHeader();
+			const svg = wrapper.find("svg");
+			expect(svg.exists()).toBe(true);
+			expect(svg.attributes("aria-hidden")).toBe("true");
+			expect(svg.classes()).toContain("h-20");
+			expect(svg.classes()).toContain("w-45");
+		});
+	});
+
+	describe("AppHeaderAuth", () => {
+		it("has no axe-core violations", async () => {
+			const wrapper = await mountSuspended(AppHeaderAuth);
+			const results = await runAxe(wrapper);
+			expect(results.violations).toEqual([]);
+		});
+
+		it("renders sign-in buttons that link to /login with an accessible name", async () => {
+			const wrapper = await mountSuspended(AppHeaderAuth);
+			const signInLinks = wrapper.findAll("a[href='/login']");
+			expect(signInLinks.length).toBeGreaterThan(0);
+			for (const link of signInLinks) {
+				expect(link.attributes("aria-label")).toBe("Sign in with Discord");
+			}
+		});
+	});
+
+	describe("AppLogoMark", () => {
+		it("has no axe-core violations", async () => {
+			const wrapper = await mountSuspended(AppLogoMark);
+			const results = await runAxe(wrapper);
+			expect(results.violations).toEqual([]);
+		});
+
+		it("marks the decorative logo as aria-hidden so it is ignored by assistive tech", async () => {
+			const wrapper = await mountSuspended(AppLogoMark);
+			const svg = wrapper.find("svg");
+			expect(svg.exists()).toBe(true);
+			expect(svg.attributes("aria-hidden")).toBe("true");
+			expect(svg.attributes("role")).toBeUndefined();
 		});
 	});
 });

--- a/test/nuxt/components/app/Footer.spec.ts
+++ b/test/nuxt/components/app/Footer.spec.ts
@@ -1,8 +1,8 @@
 import { AppFooter } from "#components";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { describe, expect, it } from "vitest";
-import { runAxe } from "../../utils/axe";
 
+// Accessibility audits for AppFooter live in test/nuxt/a11y.spec.ts.
 describe("AppFooter", () => {
 	describe("hydration safety", () => {
 		it("renders deterministically across mounts (no SSR/client divergence)", async () => {
@@ -14,36 +14,6 @@ describe("AppFooter", () => {
 		it("derives the copyright year from a computed shared by server and client", async () => {
 			const wrapper = await mountSuspended(AppFooter);
 			expect(wrapper.text()).toContain(String(new Date().getFullYear()));
-		});
-	});
-
-	describe("accessibility", () => {
-		it("has no axe-core violations", async () => {
-			const wrapper = await mountSuspended(AppFooter);
-			const results = await runAxe(wrapper);
-			expect(results.violations).toEqual([]);
-		});
-
-		it("exposes the footer landmark with an accessible name", async () => {
-			const wrapper = await mountSuspended(AppFooter);
-			expect(wrapper.find("[aria-label='Site footer']").exists()).toBe(true);
-		});
-
-		it("marks the decorative logo as an image and hides the inner svg from AT", async () => {
-			const wrapper = await mountSuspended(AppFooter);
-			const logo = wrapper.find("[role='img'][aria-label='WolfStar logo']");
-			expect(logo.exists()).toBe(true);
-			expect(logo.find("svg").attributes("aria-hidden")).toBe("true");
-		});
-
-		it("gives the external links accessible names that announce a new tab", async () => {
-			const wrapper = await mountSuspended(AppFooter);
-			expect(
-				wrapper.find("[aria-label='Powered by Netlify - opens in new tab']").exists(),
-			).toBe(true);
-			expect(
-				wrapper.find("[aria-label='Visit WolfStar on GitHub - opens in new tab']").exists(),
-			).toBe(true);
 		});
 	});
 });

--- a/test/nuxt/components/app/Header.spec.ts
+++ b/test/nuxt/components/app/Header.spec.ts
@@ -1,7 +1,6 @@
 import { AppHeader } from "#components";
 import { mockComponent, mountSuspended } from "@nuxt/test-utils/runtime";
 import { describe, expect, it } from "vitest";
-import { runAxe } from "../../utils/axe";
 
 // Stub the auth dropdown so the header test doesn't trigger a real session fetch.
 // The stub keeps an accessible name so it doesn't introduce axe violations.
@@ -13,39 +12,13 @@ mockComponent("AppHeaderAuth", async () => {
 	};
 });
 
+// Accessibility audits for AppHeader live in test/nuxt/a11y.spec.ts.
 describe("AppHeader", () => {
 	describe("hydration safety", () => {
 		it("renders deterministically across mounts (no SSR/client divergence)", async () => {
 			const first = await mountSuspended(AppHeader);
 			const second = await mountSuspended(AppHeader);
 			expect(second.html()).toBe(first.html());
-		});
-	});
-
-	describe("accessibility", () => {
-		it("has no axe-core violations", async () => {
-			const wrapper = await mountSuspended(AppHeader);
-			const results = await runAxe(wrapper);
-			expect(results.violations).toEqual([]);
-		});
-
-		it("renders the banner landmark", async () => {
-			const wrapper = await mountSuspended(AppHeader);
-			expect(wrapper.find("header").exists()).toBe(true);
-		});
-
-		it("names the primary navigation for assistive tech", async () => {
-			const wrapper = await mountSuspended(AppHeader);
-			expect(wrapper.find("[aria-label='Main navigation']").exists()).toBe(true);
-		});
-
-		it("renders the WolfStar logo mark with the resized svg hidden from AT", async () => {
-			const wrapper = await mountSuspended(AppHeader);
-			const svg = wrapper.find("svg");
-			expect(svg.exists()).toBe(true);
-			expect(svg.attributes("aria-hidden")).toBe("true");
-			expect(svg.classes()).toContain("h-20");
-			expect(svg.classes()).toContain("w-45");
 		});
 	});
 });

--- a/test/nuxt/components/app/HeaderAuth.spec.ts
+++ b/test/nuxt/components/app/HeaderAuth.spec.ts
@@ -1,7 +1,6 @@
 import { AppHeaderAuth } from "#components";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { describe, expect, it } from "vitest";
-import { runAxe } from "../../utils/axe";
 
 // `AppHeaderAuth` is a `.client.vue` component that reads the session through the
 // auth module's `useAuth` -> `useUserSession`. Those calls resolve inside the
@@ -9,6 +8,7 @@ import { runAxe } from "../../utils/axe";
 // without a real session the component renders its logged-out state, which is
 // exactly what the server emits and what the client shows before the session
 // resolves. These tests cover that default state.
+// Accessibility audits for AppHeaderAuth live in test/nuxt/a11y.spec.ts.
 describe("AppHeaderAuth", () => {
 	describe("hydration safety", () => {
 		// Client-only component: never server-rendered, so a hydration mismatch is
@@ -19,23 +19,6 @@ describe("AppHeaderAuth", () => {
 			const first = await mountSuspended(AppHeaderAuth);
 			const second = await mountSuspended(AppHeaderAuth);
 			expect(second.html()).toBe(first.html());
-		});
-	});
-
-	describe("accessibility", () => {
-		it("has no axe-core violations", async () => {
-			const wrapper = await mountSuspended(AppHeaderAuth);
-			const results = await runAxe(wrapper);
-			expect(results.violations).toEqual([]);
-		});
-
-		it("renders sign-in buttons that link to /login with an accessible name", async () => {
-			const wrapper = await mountSuspended(AppHeaderAuth);
-			const signInLinks = wrapper.findAll("a[href='/login']");
-			expect(signInLinks.length).toBeGreaterThan(0);
-			for (const link of signInLinks) {
-				expect(link.attributes("aria-label")).toBe("Sign in with Discord");
-			}
 		});
 	});
 });

--- a/test/nuxt/components/app/LogoMark.spec.ts
+++ b/test/nuxt/components/app/LogoMark.spec.ts
@@ -1,9 +1,7 @@
 import { AppLogoMark } from "#components";
-import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { renderToString } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createSSRApp, nextTick } from "vue";
-import { runAxe } from "../../utils/axe";
 
 /**
  * Substrings Vue logs (dev build) when the client render does not match the
@@ -34,6 +32,7 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
+// Accessibility audits for AppLogoMark live in test/nuxt/a11y.spec.ts.
 describe("AppLogoMark", () => {
 	describe("hydration", () => {
 		it("hydrates server-rendered markup without mismatch warnings", async () => {
@@ -88,22 +87,6 @@ describe("AppLogoMark", () => {
 			expect(container.querySelector("svg")?.getAttribute("class")).toBe("h-20 w-45");
 
 			app.unmount();
-		});
-	});
-
-	describe("accessibility", () => {
-		it("has no axe-core violations", async () => {
-			const wrapper = await mountSuspended(AppLogoMark);
-			const results = await runAxe(wrapper);
-			expect(results.violations).toEqual([]);
-		});
-
-		it("marks the decorative logo as aria-hidden so it is ignored by assistive tech", async () => {
-			const wrapper = await mountSuspended(AppLogoMark);
-			const svg = wrapper.find("svg");
-			expect(svg.exists()).toBe(true);
-			expect(svg.attributes("aria-hidden")).toBe("true");
-			expect(svg.attributes("role")).toBeUndefined();
 		});
 	});
 });

--- a/test/nuxt/utils/axe.ts
+++ b/test/nuxt/utils/axe.ts
@@ -21,6 +21,7 @@ const axeRunOptions: RunOptions = {
 		"page-has-heading-one": { enabled: false },
 		"landmark-no-duplicate-banner": { enabled: false },
 		"landmark-no-duplicate-contentinfo": { enabled: false },
+		"landmark-no-duplicate-main": { enabled: false },
 		"color-contrast": { enabled: false },
 	},
 };


### PR DESCRIPTION
Following the single-file pattern used by [npmx.dev's `test/nuxt/a11y.spec.ts`](https://github.com/npmx-dev/npmx.dev/blob/main/test/nuxt/a11y.spec.ts), this moves the accessibility coverage that was scattered across the `test/nuxt/components/app/*` specs into the central `test/nuxt/a11y.spec.ts`. Each component spec now owns only its hydration/SSR tests, and `a11y.spec.ts` is the single home for component accessibility audits.

## What moved
The `accessibility` `describe` blocks (axe-core audits plus the ARIA/landmark assertions) were relocated out of `Footer.spec.ts`, `Header.spec.ts`, `HeaderAuth.spec.ts`, and `LogoMark.spec.ts` into `a11y.spec.ts` as new `AppFooter`, `AppHeader`, `AppHeaderAuth`, and `AppLogoMark` blocks. The hydration-safety tests stay where they were.

## Notable details
- `a11y.spec.ts` previously carried its own private copy of `runAxe`/`axeRunOptions`. It now imports the shared helper from `test/nuxt/utils/axe.ts` (the same one the component specs used), removing the duplication. Without this, that shared `runAxe` export would have been left unused and tripped `knip`.
- `utils/axe.ts` gains `landmark-no-duplicate-main` in its disabled-rule set so the shared options match what `a11y.spec.ts` disabled locally before.
- `AppHeader` embeds the lazy `AppHeaderAuth` dropdown, which fetches a session on mount. `Header.spec.ts` mocked it module-wide, but that can't coexist with the real-component `AppHeaderAuth` audit in the same file. The audit instead stubs it per-mount with an accessibly-named button:

```ts
const SignInStub = {
	template: `<button type="button" aria-label="Sign in with Discord">Sign in</button>`,
};

function mountAppHeader() {
	return mountSuspended(AppHeader, {
		global: { stubs: { AppHeaderAuth: SignInStub, LazyAppHeaderAuth: SignInStub } },
	});
}
```

`AppHeaderAuth` keeps its module-level `mockComponent` stub in `Header.spec.ts` for the hydration-determinism test, where it is still needed.

No production code changed; this is a test-only reorganization.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before
        FS[Footer.spec.ts hydration + a11y]
        HS[Header.spec.ts hydration + a11y]
        HAS[HeaderAuth.spec.ts hydration + a11y]
        LMS[LogoMark.spec.ts hydration + a11y]
        OldA11y[a11y.spec.ts Discord + private runAxe]
    end
    subgraph After
        FS2[Footer.spec.ts hydration only]
        HS2[Header.spec.ts hydration only]
        HAS2[HeaderAuth.spec.ts hydration only]
        LMS2[LogoMark.spec.ts hydration only]
        NewA11y[a11y.spec.ts all a11y audits]
        AxeUtil[utils/axe.ts shared runAxe]
    end
    AxeUtil -->|imported by| NewA11y
    FS2 -.->|a11y moved| NewA11y
    HS2 -.->|a11y moved| NewA11y
    HAS2 -.->|a11y moved| NewA11y
    LMS2 -.->|a11y moved| NewA11y
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before
        FS[Footer.spec.ts hydration + a11y]
        HS[Header.spec.ts hydration + a11y]
        HAS[HeaderAuth.spec.ts hydration + a11y]
        LMS[LogoMark.spec.ts hydration + a11y]
        OldA11y[a11y.spec.ts Discord + private runAxe]
    end
    subgraph After
        FS2[Footer.spec.ts hydration only]
        HS2[Header.spec.ts hydration only]
        HAS2[HeaderAuth.spec.ts hydration only]
        LMS2[LogoMark.spec.ts hydration only]
        NewA11y[a11y.spec.ts all a11y audits]
        AxeUtil[utils/axe.ts shared runAxe]
    end
    AxeUtil -->|imported by| NewA11y
    FS2 -.->|a11y moved| NewA11y
    HS2 -.->|a11y moved| NewA11y
    HAS2 -.->|a11y moved| NewA11y
    LMS2 -.->|a11y moved| NewA11y
```

</a>

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/wolfstar-project/wolfstar.rocks/commit/af8d855c0f64eea390767ddd81dfa9867f0eec0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40395877)</sub>

<!-- /greptile_comment -->