### PR TITLE
fix: restore next-version display in UI

### DIFF
--- a/config/env.ts
+++ b/config/env.ts
@@ -106,17 +106,17 @@ export async function getFileLastUpdated(path: string) {
 }
 
 /**
- * Resolves the **current** release version from the latest reachable `v*` tag
- * on `origin/release`. Delegates to {@link getNextVersion} for tag discovery;
- * the UI must show the deployed release, not the computed next bump (that is
- * only used by `release-tag` / `release-pr` workflows).
+ * Resolves the **next** version by analysing conventional commits since the
+ * last reachable `v*` tag.  Delegates to {@link getNextVersion} which is also
+ * used by the `release-tag` and `release-pr` GitHub Actions workflows so the
+ * version shown in the UI matches the tag that will be created *after* deploy.
  *
  * Falls back to `package.json` when git is unavailable (e.g. shallow clone).
  */
 export async function getVersion() {
 	try {
-		const { current } = await getNextVersion();
-		return current;
+		const { next } = await getNextVersion();
+		return next;
 	} catch {
 		return packageVersion;
 	}


### PR DESCRIPTION
### 🔗 Linked issue

N/A — restores prior version-display behavior after an unintended regression.

### 🧭 Context

`getVersion()` in `config/env.ts` feeds the version string shown in the site UI. A recent change switched it to return `current` (the latest deployed `v*` tag) instead of `next` (the semver bump computed from conventional commits since that tag).

The `release-tag` and `release-pr` workflows already use `getNextVersion().next` when creating release tags. Showing `current` in the UI caused a mismatch: the dashboard displayed the *already deployed* version while CI was preparing the *upcoming* release tag.

### 📚 Description

- Restore `getVersion()` to return `getNextVersion().next` instead of `.current`.
- Update the JSDoc to document that the UI version should align with the tag created after deploy, matching the release workflows.
- Behavior is unchanged when git is unavailable — still falls back to `package.json`.

**Test plan**

- [x] Existing unit test `getVersion` in `test/unit/config/env.spec.ts` still passes (valid semver, no leading `v`).
- [ ] CI pre-flight (`build`, `lint`, `typecheck`, `test`) on the PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(env): update version resolution logi..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/8f7271a68bcd6ed36c78ddb79158da69da7d6a49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41398840)</sub>

<!-- /greptile_comment -->