### PR TITLE
docs: replace Gitpod badge with Ona

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ contribute to the codebase without having to install anything on your machine:
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/wolfstar-project/wolfstar.rocks)
 [![Edit in Codesandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/wolfstar-project/wolfstar.rocks)
 [![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/wolfstar-project/wolfstar.rocks)
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/wolfstar-project/wolfstar.rocks)
+[![Build with Ona](https://ona.com/build-with-ona.svg)](https://app.ona.com/#https://github.com/wolfstar-project/wolfstar.rocks)
 
 </div>
 


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue — small documentation update.

### 🧭 Context

The README cloud development badges section still linked to Gitpod. Ona is the preferred replacement for one-click cloud development environments.

**Summary:** Replaces the Gitpod badge/link with the Ona badge/link in the README cloud IDE section.

### 📚 Description

Updates the README badge row to use Ona's "Build with Ona" button and `app.ona.com` deep link instead of Gitpod.

This is a documentation-only change with no runtime impact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to a single README badge/link replacement and matches Ona’s documented README button format.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the README online development badge by running the validation script and reviewing the resulting log, which captured the command, working directory, exit code, the exact README section, parsed badge values, Ona candidate, empty Gitpod candidates, and a PASS result.
- Uploaded artifacts documenting the validation: a README badge validation log and the validation script used for the check.

<a href="https://app.greptile.com/trex/runs/13266713/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): replace Gitpod badge with ..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/05c9c4128d744915629e509029be2c34f3c093df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41802456)</sub>

<!-- /greptile_comment -->