### PR TITLE
feat(config): add multi-vendor deploy context for Vercel and Railway

### DIFF
--- a/config/deploy-context.ts
+++ b/config/deploy-context.ts
@@ -79,7 +79,7 @@ function resolveRailwayContext(): DeployContext {
 	const environmentName = process.env.RAILWAY_ENVIRONMENT_NAME?.toLowerCase();
 	const gitBranch = process.env.RAILWAY_GIT_BRANCH;
 	const isProduction = environmentName === "production";
-	const isPreview = Boolean(process.env.RAILWAY_PUBLIC_DOMAIN) && !isProduction;
+	const isPreview = environmentName !== undefined && !isProduction;
 	const isPR =
 		Boolean(gitBranch) &&
 		environmentName !== undefined &&
@@ -148,7 +148,7 @@ export function getProductionUrlFromContext(context: DeployContext): string | un
 			return normalizeUrl(process.env.URL);
 		case "vercel":
 			return normalizeUrl(
-				process.env.VERCEL_URL ?? process.env.VERCEL_PROJECT_PRODUCTION_URL,
+				process.env.VERCEL_PROJECT_PRODUCTION_URL ?? process.env.VERCEL_URL,
 			);
 		case "railway":
 			return normalizeUrl(process.env.RAILWAY_PUBLIC_DOMAIN);

--- a/config/deploy-context.ts
+++ b/config/deploy-context.ts
@@ -1,8 +1,8 @@
 import * as process from "node:process";
 
-export type DeployVendor = "netlify" | "vercel" | "railway" | "local";
+type DeployVendor = "netlify" | "vercel" | "railway" | "local";
 
-export interface DeployContext {
+interface DeployContext {
 	vendor: DeployVendor;
 	isPR: boolean;
 	prNumber: string | null;

--- a/config/deploy-context.ts
+++ b/config/deploy-context.ts
@@ -1,0 +1,158 @@
+import * as process from "node:process";
+
+export type DeployVendor = "netlify" | "vercel" | "railway" | "local";
+
+export interface DeployContext {
+	vendor: DeployVendor;
+	isPR: boolean;
+	prNumber: string | null;
+	gitBranch: string | undefined;
+	isPreview: boolean;
+	isProduction: boolean;
+	commitRef: string | undefined;
+}
+
+const RAILWAY_PERMANENT_ENVIRONMENTS = new Set(["production", "staging"]);
+
+function normalizeUrl(hostOrUrl: string | undefined): string | undefined {
+	if (!hostOrUrl) {
+		return undefined;
+	}
+
+	return hostOrUrl.startsWith("http://") || hostOrUrl.startsWith("https://")
+		? hostOrUrl
+		: `https://${hostOrUrl}`;
+}
+
+function detectVendor(): DeployVendor {
+	if (process.env.NETLIFY) {
+		return "netlify";
+	}
+
+	if (process.env.VERCEL) {
+		return "vercel";
+	}
+
+	if (process.env.RAILWAY_PROJECT_ID) {
+		return "railway";
+	}
+
+	return "local";
+}
+
+function resolveNetlifyContext(): DeployContext {
+	const isPR = process.env.PULL_REQUEST === "true";
+	const context = process.env.CONTEXT;
+	const isProduction = context === "production";
+	const isPreview = isPR || Boolean(context && context !== "production");
+
+	return {
+		vendor: "netlify",
+		isPR,
+		prNumber: process.env.REVIEW_ID || null,
+		gitBranch: process.env.BRANCH,
+		isPreview,
+		isProduction,
+		commitRef: process.env.COMMIT_REF,
+	};
+}
+
+function resolveVercelContext(): DeployContext {
+	const prNumber = process.env.VERCEL_GIT_PULL_REQUEST_ID || null;
+	const isPR = Boolean(prNumber);
+	const vercelEnv = process.env.VERCEL_ENV;
+	const isProduction = vercelEnv === "production";
+	const isPreview = vercelEnv === "preview";
+
+	return {
+		vendor: "vercel",
+		isPR,
+		prNumber,
+		gitBranch: process.env.VERCEL_GIT_COMMIT_REF,
+		isPreview,
+		isProduction,
+		commitRef: process.env.VERCEL_GIT_COMMIT_SHA,
+	};
+}
+
+function resolveRailwayContext(): DeployContext {
+	const environmentName = process.env.RAILWAY_ENVIRONMENT_NAME?.toLowerCase();
+	const gitBranch = process.env.RAILWAY_GIT_BRANCH;
+	const isProduction = environmentName === "production";
+	const isPreview = Boolean(process.env.RAILWAY_PUBLIC_DOMAIN) && !isProduction;
+	const isPR =
+		Boolean(gitBranch) &&
+		environmentName !== undefined &&
+		!RAILWAY_PERMANENT_ENVIRONMENTS.has(environmentName);
+
+	return {
+		vendor: "railway",
+		isPR,
+		prNumber: null,
+		gitBranch,
+		isPreview,
+		isProduction,
+		commitRef: process.env.RAILWAY_GIT_COMMIT_SHA,
+	};
+}
+
+function resolveLocalContext(): DeployContext {
+	return {
+		vendor: "local",
+		isPR: false,
+		prNumber: null,
+		gitBranch: undefined,
+		isPreview: false,
+		isProduction: false,
+		commitRef: undefined,
+	};
+}
+
+export function getDeployContext(): DeployContext {
+	switch (detectVendor()) {
+		case "netlify":
+			return resolveNetlifyContext();
+		case "vercel":
+			return resolveVercelContext();
+		case "railway":
+			return resolveRailwayContext();
+		default:
+			return resolveLocalContext();
+	}
+}
+
+export function getPreviewUrlFromContext(context: DeployContext): string | undefined {
+	if (!context.isPreview) {
+		return undefined;
+	}
+
+	switch (context.vendor) {
+		case "netlify":
+			return normalizeUrl(process.env.URL);
+		case "vercel":
+			return normalizeUrl(process.env.VERCEL_URL);
+		case "railway":
+			return normalizeUrl(process.env.RAILWAY_PUBLIC_DOMAIN);
+		default:
+			return undefined;
+	}
+}
+
+export function getProductionUrlFromContext(context: DeployContext): string | undefined {
+	if (!context.isProduction) {
+		return undefined;
+	}
+
+	switch (context.vendor) {
+		case "netlify":
+			return normalizeUrl(process.env.URL);
+		case "vercel":
+			return normalizeUrl(
+				process.env.VERCEL_URL ?? process.env.VERCEL_PROJECT_PRODUCTION_URL,
+			);
+		case "railway":
+			return normalizeUrl(process.env.RAILWAY_PUBLIC_DOMAIN);
+		default:
+			return undefined;
+	}
+}

--- a/config/env.ts
+++ b/config/env.ts
@@ -2,30 +2,15 @@ import * as process from "node:process";
 import Git from "simple-git";
 import { version as packageVersion } from "../package.json";
 import { getNextVersion } from "../scripts/next-version";
+import {
+	getDeployContext,
+	getPreviewUrlFromContext,
+	getProductionUrlFromContext,
+} from "./deploy-context";
 
-/**
- * Environment variable `PULL_REQUEST` provided by Netlify.
- * @see {@link https://docs.netlify.com/build/configure-builds/environment-variables/#git-metadata}
- *
- * Whether triggered by a GitHub PR
- */
-const isPR = process.env.PULL_REQUEST === "true";
+const deployContext = getDeployContext();
 
-/**
- * Environment variable `REVIEW_ID` provided by Netlify.
- * @see {@link https://docs.netlify.com/configure-builds/environment-variables/#git-metadata}
- *
- * Pull request number (if in a PR environment)
- */
-const prNumber = process.env.REVIEW_ID || null;
-
-/**
- * Environment variable `BRANCH` provided by Netlify.
- * @see {@link https://docs.netlify.com/build/configure-builds/environment-variables/#git-metadata}
- *
- * Git branch
- */
-const gitBranch = process.env.BRANCH;
+const { isPR, prNumber, gitBranch } = deployContext;
 
 export const isCanary =
 	(process.env.NODE_ENV === "production" ||
@@ -34,35 +19,9 @@ export const isCanary =
 	gitBranch === "main" &&
 	!isPR;
 
-/**
- * Environment variable `CONTEXT` provided by Netlify.
- * `dev`, `production`, `deploy-preview`, `branch-deploy`, `preview-server`, or a branch name
- * @see {@link https://docs.netlify.com/build/configure-builds/environment-variables/#build-metadata}
- *
- * Whether this is some sort of preview environment.
- */
-const isPreview = isPR || (process.env.CONTEXT && process.env.CONTEXT !== "production");
-const isProduction = process.env.CONTEXT === "production";
+export const getPreviewUrl = () => getPreviewUrlFromContext(deployContext);
 
-/**
- * Environment variable `URL` provided by Netlify.
- * This is always the current deploy URL, regardless of env.
- * @see {@link https://docs.netlify.com/build/functions/environment-variables/#functions}
- *
- * Preview URL for the current deployment, only available in preview environments.
- */
-export const getPreviewUrl = () =>
-	isPreview ? (process.env.URL ? process.env.URL : undefined) : undefined;
-
-/**
- * Environment variable `URL` provided by Netlify.
- * This is always the current deploy URL, regardless of env.
- * @see {@link https://docs.netlify.com/build/functions/environment-variables/#functions}
- *
- * Production URL for the current deployment, only available in production environments.
- */
-export const getProductionUrl = () =>
-	isProduction ? (process.env.URL ? process.env.URL : undefined) : undefined;
+export const getProductionUrl = () => getProductionUrlFromContext(deployContext);
 
 const git = Git();
 async function getGitInfo() {
@@ -75,8 +34,7 @@ async function getGitInfo() {
 
 	let commit;
 	try {
-		// Netlify: COMMIT_REF
-		commit = process.env.COMMIT_REF || (await git.revparse(["HEAD"]));
+		commit = deployContext.commitRef || (await git.revparse(["HEAD"]));
 	} catch {
 		commit = "unknown";
 	}
@@ -97,7 +55,6 @@ async function getGitInfo() {
 
 export async function getFileLastUpdated(path: string) {
 	try {
-		// Get ISO date of last commit for file
 		const date = await git.log(["-1", "--format=%cI", "--", path]);
 		return date.latest?.date || new Date().toISOString();
 	} catch {
@@ -127,6 +84,7 @@ export async function getEnv(isDevelopment: boolean) {
 		getGitInfo(),
 		getVersion(),
 	]);
+	const { isPreview } = deployContext;
 	const env = isDevelopment ? "dev" : isCanary ? "canary" : isPreview ? "preview" : "release";
 	const previewUrl = getPreviewUrl();
 	const productionUrl = getProductionUrl();

--- a/test/unit/config/deploy-context.spec.ts
+++ b/test/unit/config/deploy-context.spec.ts
@@ -93,6 +93,23 @@ describe("getDeployContext", () => {
 		});
 	});
 
+	it("treats a non-production Railway environment without a public domain as a preview", () => {
+		vi.stubEnv("RAILWAY_PROJECT_ID", "project-id");
+		vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "staging");
+		vi.stubEnv("RAILWAY_GIT_BRANCH", "main");
+		vi.stubEnv("RAILWAY_GIT_COMMIT_SHA", "ghi789");
+
+		expect(getDeployContext()).toEqual({
+			vendor: "railway",
+			isPR: false,
+			prNumber: null,
+			gitBranch: "main",
+			isPreview: true,
+			isProduction: false,
+			commitRef: "ghi789",
+		});
+	});
+
 	it("prefers Netlify when multiple vendor markers are present", () => {
 		vi.stubEnv("NETLIFY", "true");
 		vi.stubEnv("VERCEL", "1");
@@ -165,6 +182,23 @@ describe("deploy URL helpers", () => {
 		};
 
 		expect(getProductionUrlFromContext(previewContext)).toBeUndefined();
+		expect(getProductionUrlFromContext(productionContext)).toBe("https://wolfstar.rocks");
+	});
+
+	it("prefers the configured Vercel production domain over the deployment URL", () => {
+		vi.stubEnv("VERCEL_URL", "wolfstar-abc123.vercel.app");
+		vi.stubEnv("VERCEL_PROJECT_PRODUCTION_URL", "wolfstar.rocks");
+
+		const productionContext = {
+			vendor: "vercel" as const,
+			isPR: false,
+			prNumber: null,
+			gitBranch: "main",
+			isPreview: false,
+			isProduction: true,
+			commitRef: undefined,
+		};
+
 		expect(getProductionUrlFromContext(productionContext)).toBe("https://wolfstar.rocks");
 	});
 });

--- a/test/unit/config/deploy-context.spec.ts
+++ b/test/unit/config/deploy-context.spec.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	getDeployContext,
+	getPreviewUrlFromContext,
+	getProductionUrlFromContext,
+} from "../../../config/deploy-context";
+
+const ALL_VENDOR_ENV_VARS = [
+	"NETLIFY",
+	"CONTEXT",
+	"URL",
+	"PULL_REQUEST",
+	"REVIEW_ID",
+	"BRANCH",
+	"COMMIT_REF",
+	"VERCEL",
+	"VERCEL_ENV",
+	"VERCEL_URL",
+	"VERCEL_GIT_COMMIT_REF",
+	"VERCEL_GIT_COMMIT_SHA",
+	"VERCEL_GIT_PULL_REQUEST_ID",
+	"VERCEL_PROJECT_PRODUCTION_URL",
+	"RAILWAY_PROJECT_ID",
+	"RAILWAY_ENVIRONMENT_NAME",
+	"RAILWAY_PUBLIC_DOMAIN",
+	"RAILWAY_GIT_BRANCH",
+	"RAILWAY_GIT_COMMIT_SHA",
+];
+
+describe("getDeployContext", () => {
+	beforeEach(() => {
+		for (const envVar of ALL_VENDOR_ENV_VARS) {
+			vi.stubEnv(envVar, undefined);
+		}
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("detects Netlify deployments", () => {
+		vi.stubEnv("NETLIFY", "true");
+		vi.stubEnv("CONTEXT", "deploy-preview");
+		vi.stubEnv("PULL_REQUEST", "true");
+		vi.stubEnv("REVIEW_ID", "42");
+		vi.stubEnv("BRANCH", "feat/foo");
+		vi.stubEnv("COMMIT_REF", "abc123");
+
+		expect(getDeployContext()).toEqual({
+			vendor: "netlify",
+			isPR: true,
+			prNumber: "42",
+			gitBranch: "feat/foo",
+			isPreview: true,
+			isProduction: false,
+			commitRef: "abc123",
+		});
+	});
+
+	it("detects Vercel deployments", () => {
+		vi.stubEnv("VERCEL", "1");
+		vi.stubEnv("VERCEL_ENV", "preview");
+		vi.stubEnv("VERCEL_GIT_COMMIT_REF", "main");
+		vi.stubEnv("VERCEL_GIT_COMMIT_SHA", "def456");
+		vi.stubEnv("VERCEL_GIT_PULL_REQUEST_ID", "17");
+
+		expect(getDeployContext()).toEqual({
+			vendor: "vercel",
+			isPR: true,
+			prNumber: "17",
+			gitBranch: "main",
+			isPreview: true,
+			isProduction: false,
+			commitRef: "def456",
+		});
+	});
+
+	it("detects Railway deployments", () => {
+		vi.stubEnv("RAILWAY_PROJECT_ID", "project-id");
+		vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "production");
+		vi.stubEnv("RAILWAY_PUBLIC_DOMAIN", "wolfstar.rocks");
+		vi.stubEnv("RAILWAY_GIT_BRANCH", "main");
+		vi.stubEnv("RAILWAY_GIT_COMMIT_SHA", "ghi789");
+
+		expect(getDeployContext()).toEqual({
+			vendor: "railway",
+			isPR: false,
+			prNumber: null,
+			gitBranch: "main",
+			isPreview: false,
+			isProduction: true,
+			commitRef: "ghi789",
+		});
+	});
+
+	it("prefers Netlify when multiple vendor markers are present", () => {
+		vi.stubEnv("NETLIFY", "true");
+		vi.stubEnv("VERCEL", "1");
+		vi.stubEnv("RAILWAY_PROJECT_ID", "project-id");
+
+		expect(getDeployContext().vendor).toBe("netlify");
+	});
+});
+
+describe("deploy URL helpers", () => {
+	beforeEach(() => {
+		for (const envVar of ALL_VENDOR_ENV_VARS) {
+			vi.stubEnv(envVar, undefined);
+		}
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("normalizes Vercel hostnames to https URLs", () => {
+		vi.stubEnv("VERCEL_URL", "wolfstar.vercel.app");
+
+		const context = {
+			vendor: "vercel" as const,
+			isPR: false,
+			prNumber: null,
+			gitBranch: "main",
+			isPreview: true,
+			isProduction: false,
+			commitRef: undefined,
+		};
+
+		expect(getPreviewUrlFromContext(context)).toBe("https://wolfstar.vercel.app");
+	});
+
+	it("keeps Netlify URLs unchanged when already absolute", () => {
+		vi.stubEnv("URL", "https://preview.example.com");
+
+		const context = {
+			vendor: "netlify" as const,
+			isPR: true,
+			prNumber: "1",
+			gitBranch: "feat/foo",
+			isPreview: true,
+			isProduction: false,
+			commitRef: undefined,
+		};
+
+		expect(getPreviewUrlFromContext(context)).toBe("https://preview.example.com");
+	});
+
+	it("returns production URLs only for production contexts", () => {
+		vi.stubEnv("RAILWAY_PUBLIC_DOMAIN", "wolfstar.rocks");
+
+		const previewContext = {
+			vendor: "railway" as const,
+			isPR: true,
+			prNumber: null,
+			gitBranch: "feat/foo",
+			isPreview: true,
+			isProduction: false,
+			commitRef: undefined,
+		};
+
+		const productionContext = {
+			...previewContext,
+			isPreview: false,
+			isProduction: true,
+		};
+
+		expect(getProductionUrlFromContext(previewContext)).toBeUndefined();
+		expect(getProductionUrlFromContext(productionContext)).toBe("https://wolfstar.rocks");
+	});
+});

--- a/test/unit/config/env.spec.ts
+++ b/test/unit/config/env.spec.ts
@@ -229,6 +229,17 @@ describe("getEnv", () => {
 		expect(result.prNumber).toBeNull();
 	});
 
+	it('returns "preview" for non-production Railway environments without a public domain', async () => {
+		vi.resetModules();
+		stubVendorEnv("railway");
+		vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "staging");
+		vi.stubEnv("RAILWAY_GIT_BRANCH", "main");
+		const { getEnv } = await import("../../../config/env");
+		const result = await getEnv(false);
+
+		expect(result.env).toBe("preview");
+	});
+
 	it('returns "release" for Railway production deploys from non-main branch', async () => {
 		vi.resetModules();
 		stubVendorEnv("railway");
@@ -395,6 +406,17 @@ describe("getProductionUrl", () => {
 		const { getProductionUrl } = await import("../../../config/env");
 
 		expect(getProductionUrl()).toBe("https://wolfstar.vercel.app");
+	});
+
+	it("prefers the configured production domain over the deployment URL on Vercel", async () => {
+		vi.resetModules();
+		stubVendorEnv("vercel");
+		vi.stubEnv("VERCEL_ENV", "production");
+		vi.stubEnv("VERCEL_URL", "wolfstar-abc123.vercel.app");
+		vi.stubEnv("VERCEL_PROJECT_PRODUCTION_URL", "wolfstar.rocks");
+		const { getProductionUrl } = await import("../../../config/env");
+
+		expect(getProductionUrl()).toBe("https://wolfstar.rocks");
 	});
 
 	it("returns Railway production URL with https prefix", async () => {

--- a/test/unit/config/env.spec.ts
+++ b/test/unit/config/env.spec.ts
@@ -1,16 +1,50 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const ALL_ENV_VARS = ["CONTEXT", "URL", "PULL_REQUEST", "REVIEW_ID", "BRANCH", "NODE_ENV"];
+const ALL_VENDOR_ENV_VARS = [
+	"NETLIFY",
+	"CONTEXT",
+	"URL",
+	"PULL_REQUEST",
+	"REVIEW_ID",
+	"BRANCH",
+	"COMMIT_REF",
+	"VERCEL",
+	"VERCEL_ENV",
+	"VERCEL_URL",
+	"VERCEL_GIT_COMMIT_REF",
+	"VERCEL_GIT_COMMIT_SHA",
+	"VERCEL_GIT_PULL_REQUEST_ID",
+	"VERCEL_PROJECT_PRODUCTION_URL",
+	"RAILWAY_PROJECT_ID",
+	"RAILWAY_ENVIRONMENT_NAME",
+	"RAILWAY_PUBLIC_DOMAIN",
+	"RAILWAY_GIT_BRANCH",
+	"RAILWAY_GIT_COMMIT_SHA",
+	"NODE_ENV",
+] as const;
+
+function stubVendorEnv(vendor: "netlify" | "vercel" | "railway") {
+	for (const envVar of ALL_VENDOR_ENV_VARS) {
+		vi.stubEnv(envVar, undefined);
+	}
+
+	switch (vendor) {
+		case "netlify":
+			vi.stubEnv("NETLIFY", "true");
+			break;
+		case "vercel":
+			vi.stubEnv("VERCEL", "1");
+			break;
+		case "railway":
+			vi.stubEnv("RAILWAY_PROJECT_ID", "test-project-id");
+			break;
+	}
+}
 
 describe("isCanary", () => {
 	beforeEach(() => {
 		vi.resetModules();
-	});
-
-	beforeEach(() => {
-		for (const envVar of ALL_ENV_VARS) {
-			vi.stubEnv(envVar, undefined);
-		}
+		stubVendorEnv("netlify");
 	});
 
 	afterEach(() => {
@@ -62,17 +96,35 @@ describe("isCanary", () => {
 
 		expect(isCanary).toBe(false);
 	});
+
+	it("returns true on Vercel production deploys from main (non-PR)", async () => {
+		vi.resetModules();
+		stubVendorEnv("vercel");
+		vi.stubEnv("NODE_ENV", "production");
+		vi.stubEnv("VERCEL_ENV", "production");
+		vi.stubEnv("VERCEL_GIT_COMMIT_REF", "main");
+		const { isCanary } = await import("../../../config/env");
+
+		expect(isCanary).toBe(true);
+	});
+
+	it("returns false on Vercel preview deploys triggered by a pull request", async () => {
+		vi.resetModules();
+		stubVendorEnv("vercel");
+		vi.stubEnv("NODE_ENV", "production");
+		vi.stubEnv("VERCEL_ENV", "preview");
+		vi.stubEnv("VERCEL_GIT_COMMIT_REF", "main");
+		vi.stubEnv("VERCEL_GIT_PULL_REQUEST_ID", "42");
+		const { isCanary } = await import("../../../config/env");
+
+		expect(isCanary).toBe(false);
+	});
 });
 
 describe("getEnv", () => {
 	beforeEach(() => {
 		vi.resetModules();
-	});
-
-	beforeEach(() => {
-		for (const envVar of ALL_ENV_VARS) {
-			vi.stubEnv(envVar, undefined);
-		}
+		stubVendorEnv("netlify");
 	});
 
 	afterEach(() => {
@@ -150,18 +202,51 @@ describe("getEnv", () => {
 
 		expect(result.env).toBe("dev");
 	});
+
+	it('returns "preview" for Vercel preview deployments', async () => {
+		vi.resetModules();
+		stubVendorEnv("vercel");
+		vi.stubEnv("VERCEL_ENV", "preview");
+		vi.stubEnv("VERCEL_GIT_COMMIT_REF", "feat/foo");
+		vi.stubEnv("VERCEL_GIT_PULL_REQUEST_ID", "99");
+		const { getEnv } = await import("../../../config/env");
+		const result = await getEnv(false);
+
+		expect(result.env).toBe("preview");
+		expect(result.prNumber).toBe("99");
+	});
+
+	it('returns "preview" for Railway ephemeral PR environments', async () => {
+		vi.resetModules();
+		stubVendorEnv("railway");
+		vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "pr-42");
+		vi.stubEnv("RAILWAY_PUBLIC_DOMAIN", "preview.up.railway.app");
+		vi.stubEnv("RAILWAY_GIT_BRANCH", "feat/foo");
+		const { getEnv } = await import("../../../config/env");
+		const result = await getEnv(false);
+
+		expect(result.env).toBe("preview");
+		expect(result.prNumber).toBeNull();
+	});
+
+	it('returns "release" for Railway production deploys from non-main branch', async () => {
+		vi.resetModules();
+		stubVendorEnv("railway");
+		vi.stubEnv("NODE_ENV", "production");
+		vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "production");
+		vi.stubEnv("RAILWAY_PUBLIC_DOMAIN", "wolfstar.rocks");
+		vi.stubEnv("RAILWAY_GIT_BRANCH", "v1.0.0");
+		const { getEnv } = await import("../../../config/env");
+		const result = await getEnv(false);
+
+		expect(result.env).toBe("release");
+	});
 });
 
 describe("getPreviewUrl", () => {
 	beforeEach(() => {
-		// Reset consts evaluated at module init time
 		vi.resetModules();
-	});
-
-	beforeEach(() => {
-		for (const envVar of ALL_ENV_VARS) {
-			vi.stubEnv(envVar, undefined);
-		}
+		stubVendorEnv("netlify");
 	});
 
 	afterEach(() => {
@@ -222,18 +307,33 @@ describe("getPreviewUrl", () => {
 
 		expect(getPreviewUrl()).toBe(expectedUrl);
 	});
+
+	it("returns Vercel preview URL with https prefix", async () => {
+		vi.resetModules();
+		stubVendorEnv("vercel");
+		vi.stubEnv("VERCEL_ENV", "preview");
+		vi.stubEnv("VERCEL_URL", "wolfstar-git-feat.vercel.app");
+		const { getPreviewUrl } = await import("../../../config/env");
+
+		expect(getPreviewUrl()).toBe("https://wolfstar-git-feat.vercel.app");
+	});
+
+	it("returns Railway preview URL with https prefix", async () => {
+		vi.resetModules();
+		stubVendorEnv("railway");
+		vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "pr-42");
+		vi.stubEnv("RAILWAY_PUBLIC_DOMAIN", "preview.up.railway.app");
+		vi.stubEnv("RAILWAY_GIT_BRANCH", "feat/foo");
+		const { getPreviewUrl } = await import("../../../config/env");
+
+		expect(getPreviewUrl()).toBe("https://preview.up.railway.app");
+	});
 });
 
 describe("getProductionUrl", () => {
 	beforeEach(() => {
-		// Reset consts evaluated at module init time
 		vi.resetModules();
-	});
-
-	beforeEach(() => {
-		for (const envVar of ALL_ENV_VARS) {
-			vi.stubEnv(envVar, undefined);
-		}
+		stubVendorEnv("netlify");
 	});
 
 	afterEach(() => {
@@ -285,6 +385,26 @@ describe("getProductionUrl", () => {
 		const { getProductionUrl } = await import("../../../config/env");
 
 		expect(getProductionUrl()).toBe(expectedUrl);
+	});
+
+	it("returns Vercel production URL with https prefix", async () => {
+		vi.resetModules();
+		stubVendorEnv("vercel");
+		vi.stubEnv("VERCEL_ENV", "production");
+		vi.stubEnv("VERCEL_URL", "wolfstar.vercel.app");
+		const { getProductionUrl } = await import("../../../config/env");
+
+		expect(getProductionUrl()).toBe("https://wolfstar.vercel.app");
+	});
+
+	it("returns Railway production URL with https prefix", async () => {
+		vi.resetModules();
+		stubVendorEnv("railway");
+		vi.stubEnv("RAILWAY_ENVIRONMENT_NAME", "production");
+		vi.stubEnv("RAILWAY_PUBLIC_DOMAIN", "wolfstar.rocks");
+		const { getProductionUrl } = await import("../../../config/env");
+
+		expect(getProductionUrl()).toBe("https://wolfstar.rocks");
 	});
 });
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 🧭 Context

`config/env.ts` was tightly coupled to Netlify-specific environment variables (`CONTEXT`, `BRANCH`, `PULL_REQUEST`, etc.), which prevented correct build metadata when deploying to other platforms.

This change introduces a vendor abstraction layer so the same `getEnv()` API works on Netlify, Vercel, and Railway.

### 📚 Description

- Added `config/deploy-context.ts` to detect the deploy vendor and normalize git/PR/preview/production metadata.
- Refactored `config/env.ts` to consume the shared deploy context while keeping the public API unchanged (`getEnv`, `isCanary`, `getPreviewUrl`, `getProductionUrl`).
- Extended unit tests for Vercel and Railway env var mappings, plus dedicated coverage for deploy-context helpers.

**Vendor mappings**

| Concern | Netlify | Vercel | Railway |
|---------|---------|--------|---------|
| Branch | `BRANCH` | `VERCEL_GIT_COMMIT_REF` | `RAILWAY_GIT_BRANCH` |
| Commit | `COMMIT_REF` | `VERCEL_GIT_COMMIT_SHA` | `RAILWAY_GIT_COMMIT_SHA` |
| PR | `PULL_REQUEST` + `REVIEW_ID` | `VERCEL_GIT_PULL_REQUEST_ID` | ephemeral env (not `production`/`staging`) |
| Preview | `CONTEXT !== production` | `VERCEL_ENV=preview` | non-production `RAILWAY_ENVIRONMENT_NAME` |
| Production | `CONTEXT=production` | `VERCEL_ENV=production` | `RAILWAY_ENVIRONMENT_NAME=production` |

**Notes**

- Vercel and Railway hostnames are normalized to `https://` URLs.
- Railway does not expose a native PR number; `prNumber` remains `null` on Railway.
- Netlify behavior is preserved for existing deployments.

**Testing**

- `pnpm test:unit test/unit/config/env.spec.ts test/unit/config/deploy-context.spec.ts`
- `pnpm typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(config): correct Railway preview and..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/751d6187da7bac40b5ff75591f40f627876cadbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41906689)</sub>

<!-- /greptile_comment -->