### PR TITLE
ci: add Docker containerization and automated image publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+# Node dependencies
+node_modules
+.pnpm-store
+
+# Nuxt dev/build outputs
+.output
+.data
+.nuxt
+.nitro
+.netlify
+.cache
+dist
+functions
+
+# Git
+.git
+.github
+
+# Local env files
+.env
+.env.*
+!.env.example
+
+# Prisma generated files (regenerated during the build stage)
+server/database/generated/
+
+# Testing
+test
+test-results
+test-results/
+coverage/
+playwright-report/
+.codspeed
+.lighthouseci
+
+# Editors / misc
+.DS_Store
+.fleet
+.idea
+.vscode
+.cursor
+
+# Docs and non-runtime tooling
+README.md
+LICENSE.md
+AGENTS.md
+CLAUDE.md
+GEMINI.md
+.storybook
+storybook-static
+*storybook.log
+.claude
+.agents
+.devcontainer

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,15 +5,33 @@ on:
   push:
     branches:
       - main
+    # Keep in sync with the inputs COPYed in the Dockerfile so any change that can
+    # alter the production bundle republishes the `latest` image.
     paths:
       - "app/**"
-      - "server/**"
-      - "shared/**"
+      - "config/**"
+      - "content/**"
+      - "modules/**"
+      - "patches/**"
       - "public/**"
+      - "server/**"
+      - "service-worker/**"
+      - "shared/**"
+      - "scripts/next-version.ts"
+      - "content.config.ts"
+      - "nuxt.config.ts"
+      - "prisma.config.ts"
+      - "sentry.client.config.ts"
+      - "sentry.server.config.ts"
+      - "tsconfig.json"
+      - "vite.config.ts"
+      - ".nuxtrc"
       - "Dockerfile"
-      - ".github/workflows/cd.yml"
+      - ".dockerignore"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/cd.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,34 @@
+name: cd
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "app/**"
+      - "server/**"
+      - "shared/**"
+      - "public/**"
+      - "Dockerfile"
+      - ".github/workflows/cd.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  HUSKY: 0
+
+jobs:
+  publish:
+    name: Publish WolfStar.rocks latest image to GHCR
+    if: github.repository == 'wolfstar-project/wolfstar.rocks'
+    uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@main
+    secrets: inherit

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,9 +19,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  packages: write
+permissions: {}
 
 env:
   HUSKY: 0
@@ -30,5 +28,7 @@ jobs:
   publish:
     name: Publish WolfStar.rocks latest image to GHCR
     if: github.repository == 'wolfstar-project/wolfstar.rocks'
-    uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@main
-    secrets: inherit
+    permissions:
+      contents: read # reusable workflow checks out the repository
+      packages: write # push the latest image to GHCR
+    uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@553d031d3f5dc09ca41b4e1410bf4049c7e6b646

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,38 @@
+name: release-docker
+
+on:
+  # Fires right after release-tag.yml pushes a new `v*` tag on the `release` branch.
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  HUSKY: 0
+
+jobs:
+  publish-stable:
+    name: 🚀 Publish stable image to GHCR
+    if: github.repository == 'wolfstar-project/wolfstar.rocks'
+    uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@main
+    secrets: inherit
+    with:
+      tag: stable
+
+  publish-version:
+    name: 🏷️ Publish versioned image to GHCR
+    # Only tag with the version string when this run was triggered by an actual
+    # release tag (release-tag.yml); a manual workflow_dispatch has no tag ref.
+    if: github.repository == 'wolfstar-project/wolfstar.rocks' && github.ref_type == 'tag'
+    uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@main
+    secrets: inherit
+    with:
+      tag: ${{ github.ref_name }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -19,7 +19,9 @@ env:
 jobs:
   publish-stable:
     name: 🚀 Publish stable image to GHCR
-    if: github.repository == 'wolfstar-project/wolfstar.rocks'
+    # Only publish `stable` from an actual release tag (release-tag.yml pushes `v*`);
+    # a manual workflow_dispatch from a branch or non-tag ref must not overwrite it.
+    if: github.repository == 'wolfstar-project/wolfstar.rocks' && github.ref_type == 'tag'
     permissions:
       contents: read # reusable workflow checks out the repository
       packages: write # push the stable image to GHCR

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -11,9 +11,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  packages: write
+permissions: {}
 
 env:
   HUSKY: 0
@@ -22,8 +20,10 @@ jobs:
   publish-stable:
     name: 🚀 Publish stable image to GHCR
     if: github.repository == 'wolfstar-project/wolfstar.rocks'
-    uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@main
-    secrets: inherit
+    permissions:
+      contents: read # reusable workflow checks out the repository
+      packages: write # push the stable image to GHCR
+    uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@553d031d3f5dc09ca41b4e1410bf4049c7e6b646
     with:
       tag: stable
 
@@ -32,7 +32,9 @@ jobs:
     # Only tag with the version string when this run was triggered by an actual
     # release tag (release-tag.yml); a manual workflow_dispatch has no tag ref.
     if: github.repository == 'wolfstar-project/wolfstar.rocks' && github.ref_type == 'tag'
-    uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@main
-    secrets: inherit
+    permissions:
+      contents: read # reusable workflow checks out the repository
+      packages: write # push the versioned image to GHCR
+    uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@553d031d3f5dc09ca41b4e1410bf4049c7e6b646
     with:
       tag: ${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,15 @@ WORKDIR /usr/src/app
 # `.output`, so the runner needs nothing from node_modules or the source tree.
 COPY --chown=node:node --from=builder /usr/src/app/.output .output
 
+# At runtime Nitro writes fs-backed storage (fetch cache, rate limiter) and the
+# tamper-evident audit journal under the working directory. Create those directories
+# and hand the working directory to the unprivileged node user so the first cache,
+# rate-limit, or audit write doesn't fail with EACCES. Avoid recursively chowning
+# `.output` (already node-owned via COPY) to keep the final image layer small.
+RUN mkdir -p .cache/fetch .cache/ratelimiter .audit \
+	&& chown node:node /usr/src/app \
+	&& chown -R node:node .cache .audit
+
 USER node
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,78 @@
+# ================ #
+#   Base Stage     #
+# ================ #
+
+FROM --platform=$BUILDPLATFORM node:24-alpine AS base
+
+WORKDIR /usr/src/app
+
+ENV CI="true"
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+RUN apk add --no-cache dumb-init g++ make python3
+RUN corepack enable && corepack prepare pnpm@11.3.0 --activate
+
+COPY --chown=node:node pnpm-lock.yaml .
+COPY --chown=node:node pnpm-workspace.yaml .
+COPY --chown=node:node package.json .
+
+ENTRYPOINT ["dumb-init", "--"]
+
+# ================ #
+#   Builder Stage   #
+# ================ #
+
+FROM base AS builder
+
+ENV NODE_ENV="development"
+ENV HUSKY="0"
+# Nitro auto-detects hosting providers (e.g. Netlify) from CI env vars; force the
+# self-contained node-server preset so `.output` runs standalone in the runner stage.
+ENV NITRO_PRESET="node-server"
+
+COPY --chown=node:node patches/ patches/
+COPY --chown=node:node prisma.config.ts prisma.config.ts
+COPY --chown=node:node app/ app/
+COPY --chown=node:node config/ config/
+COPY --chown=node:node content/ content/
+COPY --chown=node:node modules/ modules/
+COPY --chown=node:node public/ public/
+COPY --chown=node:node server/ server/
+COPY --chown=node:node service-worker/ service-worker/
+COPY --chown=node:node shared/ shared/
+COPY --chown=node:node scripts/next-version.ts scripts/next-version.ts
+COPY --chown=node:node content.config.ts .
+COPY --chown=node:node nuxt.config.ts .
+COPY --chown=node:node sentry.client.config.ts .
+COPY --chown=node:node sentry.server.config.ts .
+COPY --chown=node:node tsconfig.json .
+COPY --chown=node:node vite.config.ts .
+COPY --chown=node:node .nuxtrc .
+
+RUN pnpm install --frozen-lockfile \
+	&& pnpm run prisma:generate \
+	&& pnpm run build
+
+# ================ #
+#   Runner Stage   #
+# ================ #
+
+FROM base AS runner
+
+ENV NODE_ENV="production"
+ENV NODE_OPTIONS="--enable-source-maps --max_old_space_size=4096"
+ENV NITRO_HOST="0.0.0.0"
+ENV NITRO_PORT="3000"
+
+WORKDIR /usr/src/app
+
+# Nitro's node-server preset traces and inlines every runtime dependency into
+# `.output`, so the runner needs nothing from node_modules or the source tree.
+COPY --chown=node:node --from=builder /usr/src/app/.output .output
+
+USER node
+
+EXPOSE 3000
+
+CMD [ "node", ".output/server/index.mjs" ]


### PR DESCRIPTION
## Summary

- Adds production-ready `Dockerfile` with optimized multi-stage builds (base → builder → runner)
- Separates build dependencies from runtime to minimize final image size
- Creates `.dockerignore` to exclude development files, tests, and build artifacts from Docker context
- Adds `cd.yml` workflow: publishes `latest` image to GHCR on main branch pushes
- Adds `release-docker.yml` workflow: publishes `stable` and version-tagged images on releases
- Uses Node.js 24 Alpine with production optimizations (source maps, 4GB heap limit)

## Testing

- Local build: `docker build .` completes successfully
- Local run: `docker run -p 3000:3000 <image>` starts and listens on port 3000
- Verify Dockerfile stages are correctly ordered (base → builder → runner)
- Confirm `.output` directory is copied from builder to runner stage
- Verify workflow trigger paths and concurrency settings
- Manual workflow dispatch via GitHub Actions UI
- GHCR publishing: Not run (requires actual GitHub release/push events)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

The image publishing workflows need fixes before merging.

`latest` can skip changes to `public-dev/**` even though those assets can affect the Docker build output, and `stable` can still be overwritten by a manual run from an existing tag.

.github/workflows/cd.yml and .github/workflows/release-docker.yml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced verification of Public Dev Assets Skip Publish by running a focused Node repro harness against the repository workflow, Dockerfile, build-env Nuxt module, and the public-dev asset, which showed that public-dev/logo.svg does not match the push path filter and would not trigger the publish workflow on main-branch changes.
- Reproduced verification of Manual Tags Publish Stable by running a Python harness that parsed the release workflow and confirmed it allows workflow\_dispatch, with the publish-stable condition evaluating to true and the stable tag selected for the v0.1.0-old manual tag context.
- The Docker runtime contract could not be conclusively validated here because the Docker CLI is unavailable in the environment, with before-state logs showing a base commit and missing Dockerfile/dockerignore and after-state logs showing the head commit with a full Dockerfile, yet docker build attempts fail due to docker: command not found.
- T-Rex produced a proof for a posted P2 finding during the PR review.
- Verified GHCR workflows validation after, showing all contract checks pass and the run ends with RESULT: PASS and exit code 0.

<a href="https://app.greptile.com/trex/runs/13322023/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fcd.yml%3A16%0A**Public%20Dev%20Assets%20Skip%20Publish**%0A%0AThe%20Docker%20build%20runs%20with%20%60NODE_ENV%3D%22development%22%60%2C%20and%20the%20Nuxt%20build%20adds%20%60public-dev%2F%60%20as%20a%20public%20asset%20directory%20in%20that%20mode.%20A%20main-branch%20change%20under%20%60public-dev%2F**%60%20can%20change%20%60.output%60%20without%20matching%20this%20path%20filter%2C%20so%20the%20%60latest%60%20image%20can%20stay%20stale.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease-docker.yml%3A24%0A**Manual%20Tags%20Publish%20Stable**%0A%0AA%20manual%20%60workflow_dispatch%60%20run%20started%20from%20an%20existing%20tag%20still%20has%20%60github.ref_type%20%3D%3D%20'tag'%60%2C%20so%20this%20job%20can%20overwrite%20%60stable%60%20outside%20the%20release-tag%20push%20path.%20Selecting%20an%20old%20or%20non-release%20tag%20can%20publish%20the%20wrong%20image%20as%20the%20stable%20release.%0A%0A&repo=wolfstar-project%2Fwolfstar.rocks&pr=268&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fcd.yml%3A16%0A**Public%20Dev%20Assets%20Skip%20Publish**%0A%0AThe%20Docker%20build%20runs%20with%20%60NODE_ENV%3D%22development%22%60%2C%20and%20the%20Nuxt%20build%20adds%20%60public-dev%2F%60%20as%20a%20public%20asset%20directory%20in%20that%20mode.%20A%20main-branch%20change%20under%20%60public-dev%2F**%60%20can%20change%20%60.output%60%20without%20matching%20this%20path%20filter%2C%20so%20the%20%60latest%60%20image%20can%20stay%20stale.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease-docker.yml%3A24%0A**Manual%20Tags%20Publish%20Stable**%0A%0AA%20manual%20%60workflow_dispatch%60%20run%20started%20from%20an%20existing%20tag%20still%20has%20%60github.ref_type%20%3D%3D%20'tag'%60%2C%20so%20this%20job%20can%20overwrite%20%60stable%60%20outside%20the%20release-tag%20push%20path.%20Selecting%20an%20old%20or%20non-release%20tag%20can%20publish%20the%20wrong%20image%20as%20the%20stable%20release.%0A%0A&pr=268&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22wolfstar-project%2Fwolfstar.rocks%22%20on%20the%20existing%20branch%20%22t3code%2Fadd-dockerfile%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22t3code%2Fadd-dockerfile%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fcd.yml%3A16%0A**Public%20Dev%20Assets%20Skip%20Publish**%0A%0AThe%20Docker%20build%20runs%20with%20%60NODE_ENV%3D%22development%22%60%2C%20and%20the%20Nuxt%20build%20adds%20%60public-dev%2F%60%20as%20a%20public%20asset%20directory%20in%20that%20mode.%20A%20main-branch%20change%20under%20%60public-dev%2F**%60%20can%20change%20%60.output%60%20without%20matching%20this%20path%20filter%2C%20so%20the%20%60latest%60%20image%20can%20stay%20stale.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Frelease-docker.yml%3A24%0A**Manual%20Tags%20Publish%20Stable**%0A%0AA%20manual%20%60workflow_dispatch%60%20run%20started%20from%20an%20existing%20tag%20still%20has%20%60github.ref_type%20%3D%3D%20'tag'%60%2C%20so%20this%20job%20can%20overwrite%20%60stable%60%20outside%20the%20release-tag%20push%20path.%20Selecting%20an%20old%20or%20non-release%20tag%20can%20publish%20the%20wrong%20image%20as%20the%20stable%20release.%0A%0A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.&repo=wolfstar-project%2Fwolfstar.rocks&uid=108079&ts=1783261180&sig=842d7fcdae3714ce5f79bd045d28b474617fc86a70e15a9a19d93dbe5411e88c&pr=268&platform=github&fid=00020d28-8dac-40d4-a2d9-b036364c1470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/cd.yml:16
**Public Dev Assets Skip Publish**

The Docker build runs with `NODE_ENV="development"`, and the Nuxt build adds `public-dev/` as a public asset directory in that mode. A main-branch change under `public-dev/**` can change `.output` without matching this path filter, so the `latest` image can stay stale.

### Issue 2 of 2
.github/workflows/release-docker.yml:24
**Manual Tags Publish Stable**

A manual `workflow_dispatch` run started from an existing tag still has `github.ref_type == 'tag'`, so this job can overwrite `stable` outside the release-tag push path. Selecting an old or non-release tag can publish the wrong image as the stable release.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["ci: gate stable image publish on a relea..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/dbfff75a1213c683a12193157f9d721c22b0d06a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41909511)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->