### PR TITLE
fix: pass NUXT_PUBLIC_SITE_URL as build arg to Dockerfile builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,13 @@ ENV HUSKY="0"
 # self-contained node-server preset so `.output` runs standalone in the runner stage.
 ENV NITRO_PRESET="node-server"
 
+# Docker build stages don't inherit the platform's service variables automatically;
+# each one needed at build time (prerendering runs here) must be declared as an ARG
+# and re-exported as ENV. Missing this made @nuxt/sitemap fail prerender with
+# "Sitemap Site URL missing!" even though NUXT_PUBLIC_SITE_URL was set on the service.
+ARG NUXT_PUBLIC_SITE_URL
+ENV NUXT_PUBLIC_SITE_URL=$NUXT_PUBLIC_SITE_URL
+
 COPY --chown=node:node patches/ patches/
 COPY --chown=node:node prisma.config.ts prisma.config.ts
 COPY --chown=node:node app/ app/


### PR DESCRIPTION
## Summary
- Beta deploys were failing during `pnpm run build` inside the Docker builder stage with `[@nuxt/sitemap] Sitemap Site URL missing!`, causing `Exiting due to prerender errors` and a non-zero build exit code.
- Root cause: the Railway service for `wolfstar.rocks` builds via a Dockerfile (not Nixpacks). Docker build stages don't automatically inherit platform/service environment variables — each one needed at build time must be declared via `ARG` and re-exported as `ENV`. `NUXT_PUBLIC_SITE_URL` was set on the beta service but never reached the builder stage where Nitro prerendering runs.
- Fix: declare `ARG NUXT_PUBLIC_SITE_URL` and `ENV NUXT_PUBLIC_SITE_URL=$NUXT_PUBLIC_SITE_URL` in the builder stage of the Dockerfile.

## Test plan
- [ ] Merge and confirm the next beta deploy (Railway service `wolfstar.rocks`, env `beta`) builds successfully past the prerender step
- [ ] Confirm `/sitemap.xml` prerenders without a `500` in the build logs
- [ ] Confirm production deploys are unaffected (production already has `NUXT_PUBLIC_SITE_URL` set, so this only adds the missing propagation path)

https://claude.ai/code/session_01D9paXy4L2QFcUwUyU8roRB

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after confirming the deployment passes the Docker build argument.

The Dockerfile change is small and placed before the existing Nuxt build step.

The remaining risk is deployment configuration: an unset build argument still leaves the builder without a site URL.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the before-state build log to verify that NUXT\_PUBLIC\_SITE\_URL was unset and that prerendering started but did not complete due to the Docker environment being unavailable.
- Reviewed the after-state build log to verify that NUXT\_PUBLIC\_SITE\_URL was propagated via ARG/ENV and set to https://beta.wolfstar.rocks, while prerendering still halted due to the same environmental constraint.
- Concluded there is no contract mismatch caused by the ARG/ENV propagation; the blocker appears environmental/incomplete execution rather than a failure of the new propagation.

<a href="https://app.greptile.com/trex/runs/13323587/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ADockerfile%3A37-38%0A**Build%20Arg%20Can%20Stay%20Empty**%0A%0ADeclaring%20%60NUXT_PUBLIC_SITE_URL%60%20as%20an%20%60ARG%60%20only%20makes%20the%20value%20available%20if%20the%20Docker%20build%20is%20invoked%20with%20%60--build-arg%20NUXT_PUBLIC_SITE_URL%3D...%60.%20When%20Railway%20starts%20this%20Docker%20build%20with%20only%20service%2Fruntime%20variables%2C%20this%20exports%20an%20empty%20value%20into%20the%20builder%20stage%20and%20the%20sitemap%20prerender%20can%20still%20fail%20with%20the%20same%20missing%20site%20URL%20error.%0A%0A&repo=wolfstar-project%2Fwolfstar.rocks&pr=270&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ADockerfile%3A37-38%0A**Build%20Arg%20Can%20Stay%20Empty**%0A%0ADeclaring%20%60NUXT_PUBLIC_SITE_URL%60%20as%20an%20%60ARG%60%20only%20makes%20the%20value%20available%20if%20the%20Docker%20build%20is%20invoked%20with%20%60--build-arg%20NUXT_PUBLIC_SITE_URL%3D...%60.%20When%20Railway%20starts%20this%20Docker%20build%20with%20only%20service%2Fruntime%20variables%2C%20this%20exports%20an%20empty%20value%20into%20the%20builder%20stage%20and%20the%20sitemap%20prerender%20can%20still%20fail%20with%20the%20same%20missing%20site%20URL%20error.%0A%0A&pr=270&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22wolfstar-project%2Fwolfstar.rocks%22%20on%20the%20existing%20branch%20%22fix%2Fdockerfile-site-url-build-arg%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdockerfile-site-url-build-arg%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ADockerfile%3A37-38%0A**Build%20Arg%20Can%20Stay%20Empty**%0A%0ADeclaring%20%60NUXT_PUBLIC_SITE_URL%60%20as%20an%20%60ARG%60%20only%20makes%20the%20value%20available%20if%20the%20Docker%20build%20is%20invoked%20with%20%60--build-arg%20NUXT_PUBLIC_SITE_URL%3D...%60.%20When%20Railway%20starts%20this%20Docker%20build%20with%20only%20service%2Fruntime%20variables%2C%20this%20exports%20an%20empty%20value%20into%20the%20builder%20stage%20and%20the%20sitemap%20prerender%20can%20still%20fail%20with%20the%20same%20missing%20site%20URL%20error.%0A%0A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.&repo=wolfstar-project%2Fwolfstar.rocks&uid=108079&ts=1783263897&sig=fe07f81ae20670ace7c6634242a0af9921dd7e6486c6b708db7bf01383e1869a&pr=270&platform=github&fid=0dcda99b-9f5c-40b1-896f-5f1163b7d7dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Dockerfile:37-38
**Build Arg Can Stay Empty**

Declaring `NUXT_PUBLIC_SITE_URL` as an `ARG` only makes the value available if the Docker build is invoked with `--build-arg NUXT_PUBLIC_SITE_URL=...`. When Railway starts this Docker build with only service/runtime variables, this exports an empty value into the builder stage and the sitemap prerender can still fail with the same missing site URL error.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(docker): pass NUXT\_PUBLIC\_SITE\_URL a..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/cebe6bba558c7547c8c11c67fcb72baaa53b8063) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41914582)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->