### PR TITLE
fix(pwa): hide service worker sourcemap reference to stop 500s on /sw.js.map

### DIFF
--- a/config/pwa.ts
+++ b/config/pwa.ts
@@ -20,6 +20,12 @@ export const pwa: ModuleOptions = {
 		// of the precache manifest so large images (e.g. OG images) don't exceed
 		// workbox's file-size limit and fail the build.
 		globIgnores: ["**/assets/blog/**"],
+		// Match the app's `sourcemap.client: "hidden"`: still emit sw.js.map for
+		// Sentry to pick up, but without a `sourceMappingURL` comment in sw.js.
+		// Without this, browsers request /sw.js.map after Sentry's
+		// filesToDeleteAfterUpload step removes it from .output/public, producing
+		// an unhandled 500 (ENOENT) on every service worker fetch.
+		sourcemap: "hidden",
 	},
 	injectRegister: "auto",
 	manifest: {


### PR DESCRIPTION
## Summary
- Beta was logging an unhandled 500 (`ENOENT`) on every `GET /sw.js.map` request.
- `sw.js` (built via `@vite-pwa/nuxt`'s `injectManifest` strategy) ships without an explicit sourcemap mode, so it emits a plain `//# sourceMappingURL=sw.js.map` comment.
- Sentry's `sourcemaps.filesToDeleteAfterUpload` (`nuxt.config.ts`) deletes `.output/**/public/**/*.map` after upload, including `sw.js.map` — but `sw.js` still references it, so browsers/devtools requesting the map hit a dangling file and Nitro surfaces it as an unhandled fatal error instead of a plain 404.
- Fix: set `injectManifest.sourcemap = "hidden"` in `config/pwa.ts`, mirroring the app's existing `sourcemap.client: "hidden"` setting — the `.map` is still generated on disk for Sentry to pick up and upload, but `sw.js` no longer carries a public reference to it.

## Test plan
- [ ] Deploy and confirm `sw.js` no longer contains a `sourceMappingURL` comment
- [ ] Confirm `GET /sw.js.map` on beta returns a normal 404 (or is simply never requested) instead of an unhandled 500
- [ ] Confirm Sentry still receives the service worker source map for symbolication

https://claude.ai/code/session_01D9paXy4L2QFcUwUyU8roRB

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after confirming the service worker build treats `"hidden"` as a Vite sourcemap mode.

- The changed code is narrow and matches the repository's hidden source map pattern.
- The only follow-up is to confirm the PWA plugin path does not pass this value through a boolean-only Workbox option.

config/pwa.ts

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aconfig%2Fpwa.ts%3A28%0A**Hidden%20Mode%20Can%20Be%20Ignored**%0A%0AIf%20this%20installed%20PWA%20pipeline%20forwards%20%60injectManifest.sourcemap%60%20to%20Workbox's%20boolean%20%60sourcemap%60%20option%20instead%20of%20Vite's%20build%20option%2C%20the%20string%20value%20is%20treated%20like%20enabled%20sourcemaps%20rather%20than%20hidden%20sourcemaps.%20A%20production%20build%20can%20still%20emit%20%60sw.js%60%20with%20a%20%60sourceMappingURL%60%2C%20so%20Sentry%20deletes%20%60sw.js.map%60%20and%20browsers%20keep%20hitting%20the%20same%20%60%2Fsw.js.map%60%20ENOENT%20path%20this%20change%20is%20meant%20to%20stop.%0A%0A&repo=wolfstar-project%2Fwolfstar.rocks&pr=271&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aconfig%2Fpwa.ts%3A28%0A**Hidden%20Mode%20Can%20Be%20Ignored**%0A%0AIf%20this%20installed%20PWA%20pipeline%20forwards%20%60injectManifest.sourcemap%60%20to%20Workbox's%20boolean%20%60sourcemap%60%20option%20instead%20of%20Vite's%20build%20option%2C%20the%20string%20value%20is%20treated%20like%20enabled%20sourcemaps%20rather%20than%20hidden%20sourcemaps.%20A%20production%20build%20can%20still%20emit%20%60sw.js%60%20with%20a%20%60sourceMappingURL%60%2C%20so%20Sentry%20deletes%20%60sw.js.map%60%20and%20browsers%20keep%20hitting%20the%20same%20%60%2Fsw.js.map%60%20ENOENT%20path%20this%20change%20is%20meant%20to%20stop.%0A%0A&pr=271&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22wolfstar-project%2Fwolfstar.rocks%22%20on%20the%20existing%20branch%20%22fix%2Fsw-sourcemap-404%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsw-sourcemap-404%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aconfig%2Fpwa.ts%3A28%0A**Hidden%20Mode%20Can%20Be%20Ignored**%0A%0AIf%20this%20installed%20PWA%20pipeline%20forwards%20%60injectManifest.sourcemap%60%20to%20Workbox's%20boolean%20%60sourcemap%60%20option%20instead%20of%20Vite's%20build%20option%2C%20the%20string%20value%20is%20treated%20like%20enabled%20sourcemaps%20rather%20than%20hidden%20sourcemaps.%20A%20production%20build%20can%20still%20emit%20%60sw.js%60%20with%20a%20%60sourceMappingURL%60%2C%20so%20Sentry%20deletes%20%60sw.js.map%60%20and%20browsers%20keep%20hitting%20the%20same%20%60%2Fsw.js.map%60%20ENOENT%20path%20this%20change%20is%20meant%20to%20stop.%0A%0A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.&repo=wolfstar-project%2Fwolfstar.rocks&uid=108079&ts=1783265250&sig=1d7b537f093a06c180335f687a2f9025160114405fe8c1b2496b22ad3019ceba&pr=271&platform=github&fid=ce9cd359-df49-4b2e-a7df-ff7a5d07a683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
config/pwa.ts:28
**Hidden Mode Can Be Ignored**

If this installed PWA pipeline forwards `injectManifest.sourcemap` to Workbox's boolean `sourcemap` option instead of Vite's build option, the string value is treated like enabled sourcemaps rather than hidden sourcemaps. A production build can still emit `sw.js` with a `sourceMappingURL`, so Sentry deletes `sw.js.map` and browsers keep hitting the same `/sw.js.map` ENOENT path this change is meant to stop.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pwa): hide service worker sourcemap ..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/4bbcee825ea535eedbb9058c91b942df1afde7b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41916898)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/wolfstar-project/github/wolfstar-project/wolfstar.rocks/-/custom-context?memory=d7db7ccf-40f4-43f6-9080-ac8602584fb3))
- Context used - AGENTS.md ([source](https://app.greptile.com/wolfstar-project/github/wolfstar-project/wolfstar.rocks/-/custom-context?memory=f03ea402-230b-4708-8d2d-8c19cf4a65bc))

<!-- /greptile_comment -->