### PR TITLE
fix: copy .git into builder so version/commit resolve correctly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,8 +12,9 @@ node_modules
 dist
 functions
 
-# Git
-.git
+# Git history is needed in the builder stage: `next-version.ts` and the
+# git-based commit/branch fallback in config/env.ts shell out to real `git`
+# commands to populate the version/commit footer shown in BuildEnvironment.vue.
 .github
 
 # Local env files

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,21 @@ ENV NITRO_PRESET="node-server"
 ARG NUXT_PUBLIC_SITE_URL
 ENV NUXT_PUBLIC_SITE_URL=$NUXT_PUBLIC_SITE_URL
 
+# Railway populates these automatically per-deploy, but (like NUXT_PUBLIC_SITE_URL
+# above) they still need an explicit ARG to reach this build stage. This lets
+# config/deploy-context.ts resolve the real commit/branch without needing `git`
+# at all when running on Railway specifically.
+ARG RAILWAY_PROJECT_ID
+ARG RAILWAY_ENVIRONMENT_NAME
+ARG RAILWAY_GIT_BRANCH
+ARG RAILWAY_GIT_COMMIT_SHA
+ARG RAILWAY_PUBLIC_DOMAIN
+ENV RAILWAY_PROJECT_ID=$RAILWAY_PROJECT_ID
+ENV RAILWAY_ENVIRONMENT_NAME=$RAILWAY_ENVIRONMENT_NAME
+ENV RAILWAY_GIT_BRANCH=$RAILWAY_GIT_BRANCH
+ENV RAILWAY_GIT_COMMIT_SHA=$RAILWAY_GIT_COMMIT_SHA
+ENV RAILWAY_PUBLIC_DOMAIN=$RAILWAY_PUBLIC_DOMAIN
+
 COPY --chown=node:node patches/ patches/
 COPY --chown=node:node prisma.config.ts prisma.config.ts
 COPY --chown=node:node app/ app/
@@ -56,6 +71,11 @@ COPY --chown=node:node sentry.server.config.ts .
 COPY --chown=node:node tsconfig.json .
 COPY --chown=node:node vite.config.ts .
 COPY --chown=node:node .nuxtrc .
+# Needed so scripts/next-version.ts and the simple-git fallback in
+# config/env.ts can resolve the real semantic version and commit/branch
+# instead of falling back to package.json's "0.0.0" placeholder and
+# "unknown". See .dockerignore for why .git is no longer excluded.
+COPY --chown=node:node .git .git
 
 RUN pnpm install --frozen-lockfile \
 	&& pnpm run prisma:generate \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,14 @@ ENTRYPOINT ["dumb-init", "--"]
 
 FROM base AS builder
 
+# scripts/next-version.ts (execFileSync "git", ...) and the simple-git fallback in
+# config/env.ts shell out to the `git` binary at build time to resolve the real
+# semantic version and commit/branch. The Alpine `base` stage ships no git, so
+# without it getVersion() silently falls back to package.json's "0.0.0" and
+# getGitInfo() to "unknown" even with .git copied in below. Installed only in the
+# builder stage so the runner image stays git-free.
+RUN apk add --no-cache git
+
 ENV NODE_ENV="development"
 ENV HUSKY="0"
 # Nitro auto-detects hosting providers (e.g. Netlify) from CI env vars; force the


### PR DESCRIPTION
## Summary
The `BuildEnvironment.vue` footer showed **"v0.0.0 · unknown"** on beta instead of a real version/commit.

Root cause: `nuxt build` runs inside the Docker builder stage, which is where `modules/build-env.ts` computes `buildInfo` (version, commit, branch) via `config/env.ts`. That resolution needs either:
- Railway's own `RAILWAY_GIT_COMMIT_SHA`/`RAILWAY_GIT_BRANCH` vars (via `config/deploy-context.ts`), or
- a real `.git` directory for `scripts/next-version.ts` (tag-based semver) and the `simple-git` fallback in `config/env.ts`.

Neither was available in the builder stage: the Railway vars were never declared as Docker `ARG`s (same class of bug as the `NUXT_PUBLIC_SITE_URL` fix in #270), and `.git` was explicitly excluded via `.dockerignore`. Both paths failed, so `getVersion()` fell back to `package.json`'s `"0.0.0"` placeholder and `getGitInfo()` fell back to `"unknown"`.

## Fix
- Removed `.git` from `.dockerignore` and added `COPY --chown=node:node .git .git` to the builder stage. Verified locally by running `getEnv()` directly against this repo's real `.git`:
  ```json
  { "version": "0.10.0", "commit": "210dceab...", "shortCommit": "210dcea", "branch": "fix/version-commit-display", ... }
  ```
  instead of `{ "version": "0.0.0", "commit": "unknown", ... }`.
- This only grows the **builder stage's** intermediate layer (~83MB, this repo's current `.git` size) — the **runner stage** (the actual deployed image) only copies `.output` from the builder, so final image size and pull time are unaffected. Build time/context-transfer will increase slightly on every build.
- Also added `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_NAME`, `RAILWAY_GIT_BRANCH`, `RAILWAY_GIT_COMMIT_SHA`, `RAILWAY_PUBLIC_DOMAIN` as build `ARG`s/`ENV`s, mirroring the `NUXT_PUBLIC_SITE_URL` fix — gives `config/deploy-context.ts` a git-independent path to the correct commit/branch/vendor detection on Railway, as a fallback in case Railway's own build checkout has shallow/tag-less history.

## Test plan
- [x] `pnpm typecheck` passes
- [x] Verified `getEnv()` resolves real version/commit/branch locally with `.git` present
- [ ] Deploy to beta and confirm the footer shows a real `vX.Y.Z` and short commit instead of `v0.0.0 · unknown`
- [ ] Sanity-check build duration hasn't regressed meaningfully due to the added `.git` context transfer

https://claude.ai/code/session_01D9paXy4L2QFcUwUyU8roRB

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to Docker build-time metadata resolution. The builder now has both `.git` and the `git` binary needed by `scripts/next-version.ts` and `simple-git`. The runner image still only receives `.output`, so `.git` and the builder-only tooling are not copied into the deployed runtime image.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the full set of code-execution checks and saved per-check logs that include the exact command, working directory, captured output, and exit code for each check.
- Verified the environment blocker by checking for the docker binary; command -v docker returned exit code 127.
- Created five log artifacts documenting each executed check for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/13328667/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: install git in builder stage so ver..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/98845161d0b7959ea8d8c2ef7188616bf40638d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41925005)</sub>

<!-- /greptile_comment -->