### PR TITLE
fix: build runtime image for target arch to prevent dumb-init exec format crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,13 @@
 #   Base Stage     #
 # ================ #
 
-FROM --platform=$BUILDPLATFORM node:24-alpine AS base
+# Do NOT pin to $BUILDPLATFORM: the `runner` stage inherits from `base`, so pinning
+# the base image to the builder's architecture bakes build-host binaries (dumb-init,
+# node, …) into the runtime image. When the build host arch differs from the run host
+# arch (Railway build vs run node, or a QEMU-emulated multi-arch CI leg), the container
+# crashes on start with `/usr/bin/dumb-init: Exec format error`. Omitting --platform
+# lets Docker build natively for $TARGETPLATFORM so every binary matches the run arch.
+FROM node:24-alpine AS base
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Problem

The Dockerfile-built image can crash on startup with:

```
exec container process `/usr/bin/dumb-init`: Exec format error
```

a CPU-architecture mismatch between the image's binaries and the host.

## Root cause

The base stage pinned the image to the **build** platform:

```dockerfile
FROM --platform=$BUILDPLATFORM node:24-alpine AS base
```

The `runner` stage does `FROM base`, so the *runtime* image inherits the build-host architecture. When the build host arch differs from the run host arch — Railway building the Dockerfile on one arch and running it on another, or a QEMU-emulated multi-arch CI leg — the resulting image's binaries (including the `dumb-init` ENTRYPOINT) are the wrong arch and the container dies immediately.

`--platform=$BUILDPLATFORM` is only appropriate for cross-compilation *builder* stages that emit target-arch artifacts. This is a plain Node app — nothing is cross-compiled — so the runtime image must target `$TARGETPLATFORM` (the default).

## Fix

Drop the `--platform` pin so Docker builds natively for `$TARGETPLATFORM`; every binary in the final image then matches the arch it runs on. Mirrors wolfstar-project/staryl#51, which fixes the identical pattern there.

https://claude.ai/code/session_017sTG48MdcAHAmkqEbAQ9tM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to Docker image platform resolution and matches Docker BuildKit target-platform behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted a Docker availability check from the project repository, which exited with code 127.
- T-Rex ran the static Dockerfile architecture validation using the helper script validate-dockerfile-architecture.sh, and it completed with exit code 0.

<a href="https://app.greptile.com/trex/runs/13339499/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: build runtime image for target arch..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/0e2057f63e60dfda721337a9140c5acaddb572bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41948967)</sub>

<!-- /greptile_comment -->