### PR TITLE
chore(docs): update AGENTS.md to reflect recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - Add comments only to explain complex logic or non-obvious implementations
 - Write unit tests for core functionality using `vitest`
 - Write end-to-end tests using Playwright and `@nuxt/test-utils`
+- Consolidate component accessibility (axe) assertions into `test/nuxt/a11y.spec.ts` instead of scattering `runAxe()` checks across individual component spec files; keep hydration/behavior tests in the component's own spec file
 - Keep functions focused and manageable (generally under 50 lines)
 - Use error handling patterns consistently
 - Ensure you write strictly type-safe code, for example by ensuring you always check when accessing an array value by index
@@ -36,6 +37,8 @@
 - Routes go under `server/api/` with HTTP suffix (`.get.ts`, `.post.ts`)
 - Always wrap handlers with `defineWrappedResponseHandler` for auth + rate limiting
 - Use `defineWrappedCachedResponseHandler` for cached responses
+- Rate limiting (`server/utils/wrappedEventHandler.ts`) reserves a fixed- or sliding-window quota in storage before the handler runs and rolls the reservation back if the handler throws; it fails open (lets the request through) if the rate-limit storage read/write itself errors
+- Use the `authorize` option (not an inline check in the handler body) for per-request permission checks — e.g. `canManage()` — that must run on every request, including warm cache hits on `defineWrappedCachedResponseHandler` routes
 - Use `createError` for error responses with proper status codes
 - Use the `onError` callback for error logging
 - Validate query strings with shared Valibot schemas from `shared/schemas/` via `getValidatedQuery(event, (body) => parse(Schema, body))`
@@ -49,7 +52,7 @@
 
 ## Auth and Feedback
 
-- Discord OAuth requests the `guilds.members.read` and `email` scopes in `server/api/auth/discord.get.ts`
+- `server/api/auth/discord.get.ts` requests the `guilds.members.read` and `email` scopes and handles both legs of the OAuth flow: with no `code` query param it initiates (sets HMAC-signed nonce/redirect cookies via `createOAuthState()`); with a `code` present it is the callback, which verifies and consumes the CSRF state via `verifyOAuthState()` in `server/utils/oauth-state.ts` **before** any code exchange, then returns `{ redirectUrl }`. There is no separate `verify-state` endpoint — do not reintroduce one
 - The `#auth-utils` `User` type includes `email: string | null`; always handle existing sessions where `user.email` is still `null`
 - Feedback UI uses the custom Sentry feedback flow under `app/components/feedback/`
 - Keep feedback validation in `shared/schemas/feedback.ts` so forms and submit handlers share the same Valibot schema
@@ -81,6 +84,12 @@ pnpm test:perf:prebuilt          # Lighthouse performance checks against an exis
 pnpm test:bench                  # Vitest benchmark suite
 pnpm start:playwright:webserver  # Preview a test build on port 5678 for Playwright
 pnpm audit:verify                # Replay and verify the AuditEvent hash chain
+pnpm design:lint                 # Lint .claude/DESIGN.md with designmd
+pnpm storybook                   # Start Storybook dev server (http://localhost:6006)
+pnpm build-storybook             # Build static Storybook output
+pnpm chromatic                   # Publish Storybook to Chromatic for visual review
+pnpm vp run zizmor               # Lint GitHub Actions workflows for security issues (zizmor)
+pnpm vp run zizmor:fix           # Auto-fix zizmor findings
 pnpm prisma:push                 # Push schema changes (development)
 pnpm prisma:migrate:dev          # Create and apply migration
 pnpm prisma:migrate:dev:create   # Create a migration without applying it
@@ -110,6 +119,7 @@ pnpm update:interactive          # Interactive dependency updates with taze
 - Use `defineWrappedCachedResponseHandler` with `auth: true`, explicit `maxAge`, `swr: false`, `onError`, and route-specific rate limits for log endpoints
 - Validate log route filters with `DashboardActivityQuerySchema`, `CommandLogQuerySchema`, or `ModerationLogQuerySchema` from `shared/schemas/log-queries.ts`
 - Use `resolveGuildMembers()` and `fallbackMember()` from `server/utils/audit/resolve-members.ts` when log rows need Discord member metadata
+- Guild permission checks (`canManage()`) belong in the `authorize` option, not the handler body, so they still run when the response is served from cache
 - Client-side log data access lives in focused composables (`useAuditLog`, `useCommandLog`, `useModerationLog`) that accept `MaybeRefOrGetter` inputs and expose computed `entries` and `total`
 
 ## View Transitions
@@ -156,6 +166,7 @@ Commit messages must follow Conventional Commits: `<type>(<scope>): <subject>`
 - **OAuth redirect fails:** Ensure `.env` `NUXT_OAUTH_DISCORD_REDIRECT_URL` matches Discord Developer Portal exactly
 - **Hot reload broken:** Check file watcher limits on Linux, restart dev server
 - **Type errors after updates:** Run `pnpm nuxt prepare && pnpm prisma:generate`
+- **Duplicate/incompatible `vue` or `discord-api-types` types after a dependency update:** Check the `overrides` in `pnpm-workspace.yaml` still pin a single version of each — two copies make structurally identical (nominally-branded) types incompatible during typecheck
 
 **When in doubt:** Copy existing patterns from similar files (e.g., `server/api/guilds/**`, `app/components/discord/**`) before inventing new ones.
 
@@ -224,7 +235,8 @@ log.audit(
 - `server/utils/audit/resolve-members.ts` — resolves Discord guild members for log display with fallback placeholders
 - `server/plugins/evlog-drain.ts` — routes audit events to the drain
 - `server/plugins/evlog-enrich.ts` — enriches events with UA, trace, and audit context
-- `scripts/audit-verify.ts` — offline hash-chain verifier run with `pnpm audit:verify`
+- `shared/audit/persisted.ts` — reconstructs chain order from `prevHash` linkage (timestamps are not assumed unique) and reports topology problems (forks, cycles, multiple/no roots, unreachable rows, head mismatch) plus hash/link failures
+- `scripts/audit-verify.ts` — offline hash-chain verifier run with `pnpm audit:verify`; loads all `AuditEvent` rows and the `AuditChainHead` row, then delegates to `verifyPersistedAuditChain()` in `shared/audit/persisted.ts`
 
 ### Dashboard Activity Feed
 


### PR DESCRIPTION
### 🔗 Linked issue

None — routine weekly AGENTS.md maintenance pass.

### 🧭 Context

This is a scheduled routine that reviews PRs merged into `main` in the last 7 days and updates `AGENTS.md` (the primary AI-agent instruction file) when the codebase has drifted from what it documents.

### 📚 Description

Reviewed PRs merged since 2026-06-28 and found several undocumented patterns and stale gaps, most from #264 (the security/rate-limiting/audit PR):

- **OAuth flow consolidation (#264):** `server/api/auth/verify-state.get.ts` was removed; `server/api/auth/discord.get.ts` now verifies the HMAC-signed CSRF state inline on the callback leg (via `verifyOAuthState()` in `server/utils/oauth-state.ts`) before any code exchange. Documented this so agents don't reintroduce a separate verify-state endpoint.
- **Rate limiting is now a real implementation (#264):** `server/utils/wrappedEventHandler.ts` reserves a fixed/sliding-window quota in storage before the handler runs, rolls it back on handler failure, and fails open if the rate-limit storage itself errors. Added a line documenting this behavior.
- **New `authorize` option (#264):** guild log routes (`server/api/guilds/[guild]/logs/*`) now run permission checks (`canManage()`) via a dedicated `authorize` hook so they still execute on warm cache hits, instead of an inline check in the handler body that only runs on cache misses. Documented in both "Server API Patterns" and "Guild Logs and Activity Patterns".
- **`shared/audit/persisted.ts` (#264):** new file that reconstructs the audit hash chain from `prevHash` linkage and detects topology problems (forks, cycles, multiple/no roots, unreachable rows, head mismatch); `scripts/audit-verify.ts` now delegates to it. Added to the Audit Logging "Key Files" list.
- **Accessibility test consolidation (#257):** per-component `runAxe()` checks were moved out of individual component spec files into a single `test/nuxt/a11y.spec.ts`. Added a Code Quality Requirements bullet so new component tests follow the same convention.
- **Development Commands gaps:** `pnpm design:lint`, `pnpm storybook`, `pnpm build-storybook`, `pnpm chromatic`, and `pnpm vp run zizmor(:fix)` (added via #258's CONTRIBUTING.md restructure) were missing from the AGENTS.md command list.
- **Troubleshooting:** added a note that `pnpm-workspace.yaml` pins a single `vue`/`discord-api-types` version to prevent duplicate nominal types after dependency updates (introduced in #264).

No changes were needed elsewhere — the rest of AGENTS.md still matches the current codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0194FhMDpqhLMGYqJi55AQ17)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Documentation-only changes are safe to merge.

The updated guidance matches the checked OAuth, rate limiting, cached authorization, audit verification, accessibility, command, and workspace override files.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding, linked to the corresponding review comment for details.
- T-Rex completed general contract validation, including a before-check for 37 commands and an after-check for 43 commands, plus targeted validations showing designmd lint succeeds while certain zizmor commands fail due to missing executable.
- Artifacts summarizing the contract validation results were uploaded for review.

<a href="https://app.greptile.com/trex/runs/13344795/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(docs): update AGENTS.md to reflect..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/a5d1e235a185882e3a9a507b94ec334c3a249e20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41959069)</sub>

<!-- /greptile_comment -->