### PR TITLE
feat: add @vercel/speed-insights and update privacy policy for Vercel

### DIFF
--- a/app/pages/(marketing)/privacy.vue
+++ b/app/pages/(marketing)/privacy.vue
@@ -132,7 +132,7 @@
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
 							<span>
 								<span class="font-semibold"
-									>Hosting provider cookies (Netlify):</span
+									>Hosting provider cookies (Vercel):</span
 								>
 								Our hosting/CDN may set essential operational cookies (caching,
 								routing, preview or identity/session features). These are
@@ -222,11 +222,12 @@
 						Analytics
 					</h2>
 					<p class="mb-4 leading-relaxed text-base-content">
-						We use Netlify Analytics to understand how visitors use our website. This
-						helps us improve the user experience and identify issues.
+						We use Vercel Speed Insights to measure page performance (page load speed
+						and Core Web Vitals) and understand how visitors experience our website.
+						This helps us improve performance and identify issues.
 					</p>
 					<p class="mb-3 leading-relaxed text-base-content">
-						Netlify Analytics is designed with privacy in mind:
+						Vercel Speed Insights is designed with privacy in mind:
 					</p>
 					<ul class="list-none space-y-2 pl-0 text-base-content">
 						<li class="flex items-start gap-3 leading-relaxed">
@@ -235,7 +236,7 @@
 						</li>
 						<li class="flex items-start gap-3 leading-relaxed">
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
-							<span>It does not collect personal identifiers</span>
+							<span>It does not collect personal identifiers or IP addresses</span>
 						</li>
 						<li class="flex items-start gap-3 leading-relaxed">
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
@@ -243,18 +244,24 @@
 						</li>
 						<li class="flex items-start gap-3 leading-relaxed">
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
-							<span>All data is aggregated and anonymised</span>
+							<span
+								>All data is anonymous and cannot be used to reconstruct a browsing
+								session or identify a user</span
+							>
 						</li>
 						<li class="flex items-start gap-3 leading-relaxed">
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
-							<span>Data is collected server-side, not from your browser</span>
+							<span
+								>Data is measured by a script running in your browser (using native
+								browser performance APIs) and reported directly to Vercel
+							</span>
 						</li>
 					</ul>
 					<p class="mt-4 leading-relaxed text-base-content">
-						The only information collected includes: page URLs, referrer,
-						country/region, device type, browser, and operating system. This data cannot
-						be used to identify individual users. All analytics data is processed
-						server-side by our hosting provider.
+						The only information collected includes: page route/URL, approximate network
+						speed, browser, device type and operating system, country/region, and page
+						performance measurements (Web Vitals). This data cannot be used to identify
+						individual users and is processed by Vercel on our behalf.
 					</p>
 				</section>
 
@@ -636,8 +643,8 @@
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
 							<span>
 								<span class="font-semibold">Analytics Data:</span> Retained in
-								aggregate form by Netlify and cannot be linked to individual users.
-								Retained according to Netlify's data retention policy.
+								anonymous form by Vercel and cannot be linked to individual users.
+								Retained according to Vercel's data retention policy.
 							</span>
 						</li>
 						<li class="flex items-start gap-3 leading-relaxed">

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -13,6 +13,7 @@ const { resolve } = createResolver(import.meta.url);
 export default defineNuxtConfig({
 	// Modules configuration
 	modules: [
+		"@vercel/speed-insights",
 		"@nuxt/ui",
 		"@nuxt/content",
 		"@nuxt/image",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"@sapphire/ratelimits": "^2.4.11",
 		"@sentry/nuxt": "^10.42.0",
 		"@vercel/functions": "^3.7.5",
+		"@vercel/speed-insights": "^2.0.0",
 		"@vite-pwa/assets-generator": "^1.0.2",
 		"@vite-pwa/nuxt": "^1.1.1",
 		"@vitest/browser-playwright": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@vercel/functions':
         specifier: ^3.7.5
         version: 3.7.5(@aws-sdk/credential-provider-web-identity@3.972.39)(ws@8.21.0)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(nuxt@4.4.2)(react@19.2.5)(vue-router@5.0.4)(vue@3.5.38)
       '@vite-pwa/assets-generator':
         specifier: ^1.0.2
         version: 1.0.2
@@ -6211,6 +6214,32 @@ packages:
   '@vercel/oidc@3.8.0':
     resolution: {integrity: sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==}
     engines: {node: '>= 20'}
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: 3.5.38
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vite-pwa/assets-generator@1.0.2':
     resolution: {integrity: sha512-MCbrb508JZHqe7bUibmZj/lyojdhLRnfkmyXnkrCM2zVrjTgL89U8UEfInpKTvPeTnxsw2hmyZxnhsdNR6yhwg==}
@@ -19546,6 +19575,13 @@ snapshots:
       '@vercel/cli-config': 0.2.0
       '@vercel/cli-exec': 1.0.0
       jose: 5.10.0
+
+  '@vercel/speed-insights@2.0.0(nuxt@4.4.2)(react@19.2.5)(vue-router@5.0.4)(vue@3.5.38)':
+    optionalDependencies:
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6)(@electric-sql/pglite@0.4.1)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.6)(@types/node@24.12.4)(@vercel/functions@3.7.5)(@voidzero-dev/vite-plus-core@0.1.19)(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@9.39.4)(ioredis@5.10.1)(magicast@0.5.3)(meow@13.2.0)(mysql2@3.15.3)(optionator@0.9.4)(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1)(rollup@4.60.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vue-tsc@3.3.2)(yaml@2.9.0)
+      react: 19.2.5
+      vue: 3.5.38(typescript@6.0.3)
+      vue-router: 5.0.4(@voidzero-dev/vite-plus-core@0.1.19)(@vue/compiler-sfc@3.5.38)(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.0)(vue@3.5.38)
 
   '@vite-pwa/assets-generator@1.0.2':
     dependencies:


### PR DESCRIPTION
## Summary

- Registers `@vercel/speed-insights` as a Nuxt module, mirroring [npmx-dev/npmx.dev](https://github.com/npmx-dev/npmx.dev)'s usage (bare module specifier, no extra config) — measures Core Web Vitals now that the app is deployed on Vercel.
- Updates the privacy policy's analytics section: replaces "Netlify Analytics" with "Vercel Speed Insights" and corrects the data-collection description to match Vercel's actual behavior (client-side script using native browser performance APIs, not server-side as Netlify's was — see [Vercel's Speed Insights privacy docs](https://vercel.com/docs/speed-insights/privacy-policy)). Data remains anonymous: no cookies, no personal identifiers/IPs, no cross-site tracking.
- Renames the remaining "Netlify" mentions (hosting-provider cookies, analytics retention) to "Vercel".

## Verification

- `pnpm typecheck` ✓
- `pnpm lint:fix` ✓ (0 errors)
- `pnpm build` ✓
- `pnpm test:unit` ✓ (905/905)

https://claude.ai/code/session_017sTG48MdcAHAmkqEbAQ9tM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 3/5</h3>

The module wires up cleanly and the privacy policy text is accurate, but Speed Insights will be silently non-functional in production until the CSP is fixed.

The production `connect-src` directive does not include `https://vitals.vercel-insights.com`, which is the endpoint the SDK posts Web Vitals beacons to. Because `nuxt-security` only activates in `$production`, the module passes tests and dev builds but every beacon will be dropped by the browser's CSP enforcement once deployed. The feature is effectively dead on arrival in production without a one-line CSP addition.

nuxt.config.ts — the `connect-src` array inside the `security.headers.contentSecurityPolicy` block needs `https://vitals.vercel-insights.com` added.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Anuxt.config.ts%3A467-479%0A**Speed%20Insights%20beacons%20blocked%20by%20CSP%20in%20production**%0A%0A%60nuxt-security%60%20is%20loaded%20only%20in%20%60%24production%60%20and%20enforces%20the%20explicit%20%60connect-src%60%20list%20defined%20here.%20%60%40vercel%2Fspeed-insights%60%20reports%20Web%20Vitals%20by%20sending%20a%20%60fetch%60%2F%60sendBeacon%60%20to%20%60https%3A%2F%2Fvitals.vercel-insights.com%60%2C%20but%20that%20origin%20is%20absent%20from%20%60connect-src%60.%20The%20browser%20will%20silently%20drop%20every%20beacon%20in%20production%2C%20so%20the%20Vercel%20dashboard%20will%20show%20no%20Speed%20Insights%20data%20even%20though%20the%20module%20is%20installed.%20A%20%5BCSP-related%20issue%20in%20the%20speed-insights%20tracker%5D%28https%3A%2F%2Fgithub.com%2Fvercel%2Fspeed-insights%2Fissues%2F103%29%20specifically%20names%20this%20endpoint%20as%20required.%20Add%20%60%22https%3A%2F%2Fvitals.vercel-insights.com%22%60%20to%20the%20%60connect-src%60%20array.%0A%0A%23%23%23%20Issue%202%20of%202%0Apnpm-lock.yaml%3A6234%0A**%60vue-router%60%20peer%20dependency%20version%20mismatch**%0A%0AThe%20published%20package%20metadata%20for%20%60%40vercel%2Fspeed-insights%402.0.0%60%20declares%20%60vue-router%3A%20%5E4%60%20as%20a%20peer%20dependency%2C%20but%20the%20project%20resolves%20%60vue-router%405.0.4%60%20%28a%20major%20bump%29.%20pnpm%20accepted%20the%20resolution%20and%20the%20build%20passes%20today%2C%20but%20the%20declared%20range%20%60%5E4%60%20semantically%20excludes%20v5%2C%20so%20future%20%60pnpm%20install%20--strict-peer-dependencies%60%20runs%20or%20CI%20peer-dep%20checks%20may%20warn%20or%20error%20here.%20It's%20worth%20opening%20a%20compatibility%20issue%20upstream%20or%20pinning%20the%20resolution%20if%20this%20becomes%20a%20problem%20during%20a%20pnpm%20upgrade.%0A%0A&repo=wolfstar-project%2Fwolfstar.rocks&pr=277&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Anuxt.config.ts%3A467-479%0A**Speed%20Insights%20beacons%20blocked%20by%20CSP%20in%20production**%0A%0A%60nuxt-security%60%20is%20loaded%20only%20in%20%60%24production%60%20and%20enforces%20the%20explicit%20%60connect-src%60%20list%20defined%20here.%20%60%40vercel%2Fspeed-insights%60%20reports%20Web%20Vitals%20by%20sending%20a%20%60fetch%60%2F%60sendBeacon%60%20to%20%60https%3A%2F%2Fvitals.vercel-insights.com%60%2C%20but%20that%20origin%20is%20absent%20from%20%60connect-src%60.%20The%20browser%20will%20silently%20drop%20every%20beacon%20in%20production%2C%20so%20the%20Vercel%20dashboard%20will%20show%20no%20Speed%20Insights%20data%20even%20though%20the%20module%20is%20installed.%20A%20%5BCSP-related%20issue%20in%20the%20speed-insights%20tracker%5D%28https%3A%2F%2Fgithub.com%2Fvercel%2Fspeed-insights%2Fissues%2F103%29%20specifically%20names%20this%20endpoint%20as%20required.%20Add%20%60%22https%3A%2F%2Fvitals.vercel-insights.com%22%60%20to%20the%20%60connect-src%60%20array.%0A%0A%23%23%23%20Issue%202%20of%202%0Apnpm-lock.yaml%3A6234%0A**%60vue-router%60%20peer%20dependency%20version%20mismatch**%0A%0AThe%20published%20package%20metadata%20for%20%60%40vercel%2Fspeed-insights%402.0.0%60%20declares%20%60vue-router%3A%20%5E4%60%20as%20a%20peer%20dependency%2C%20but%20the%20project%20resolves%20%60vue-router%405.0.4%60%20%28a%20major%20bump%29.%20pnpm%20accepted%20the%20resolution%20and%20the%20build%20passes%20today%2C%20but%20the%20declared%20range%20%60%5E4%60%20semantically%20excludes%20v5%2C%20so%20future%20%60pnpm%20install%20--strict-peer-dependencies%60%20runs%20or%20CI%20peer-dep%20checks%20may%20warn%20or%20error%20here.%20It's%20worth%20opening%20a%20compatibility%20issue%20upstream%20or%20pinning%20the%20resolution%20if%20this%20becomes%20a%20problem%20during%20a%20pnpm%20upgrade.%0A%0A&pr=277&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22wolfstar-project%2Fwolfstar.rocks%22%20on%20the%20existing%20branch%20%22feat%2Fvercel-speed-insights%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fvercel-speed-insights%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Anuxt.config.ts%3A467-479%0A**Speed%20Insights%20beacons%20blocked%20by%20CSP%20in%20production**%0A%0A%60nuxt-security%60%20is%20loaded%20only%20in%20%60%24production%60%20and%20enforces%20the%20explicit%20%60connect-src%60%20list%20defined%20here.%20%60%40vercel%2Fspeed-insights%60%20reports%20Web%20Vitals%20by%20sending%20a%20%60fetch%60%2F%60sendBeacon%60%20to%20%60https%3A%2F%2Fvitals.vercel-insights.com%60%2C%20but%20that%20origin%20is%20absent%20from%20%60connect-src%60.%20The%20browser%20will%20silently%20drop%20every%20beacon%20in%20production%2C%20so%20the%20Vercel%20dashboard%20will%20show%20no%20Speed%20Insights%20data%20even%20though%20the%20module%20is%20installed.%20A%20%5BCSP-related%20issue%20in%20the%20speed-insights%20tracker%5D%28https%3A%2F%2Fgithub.com%2Fvercel%2Fspeed-insights%2Fissues%2F103%29%20specifically%20names%20this%20endpoint%20as%20required.%20Add%20%60%22https%3A%2F%2Fvitals.vercel-insights.com%22%60%20to%20the%20%60connect-src%60%20array.%0A%0A%23%23%23%20Issue%202%20of%202%0Apnpm-lock.yaml%3A6234%0A**%60vue-router%60%20peer%20dependency%20version%20mismatch**%0A%0AThe%20published%20package%20metadata%20for%20%60%40vercel%2Fspeed-insights%402.0.0%60%20declares%20%60vue-router%3A%20%5E4%60%20as%20a%20peer%20dependency%2C%20but%20the%20project%20resolves%20%60vue-router%405.0.4%60%20%28a%20major%20bump%29.%20pnpm%20accepted%20the%20resolution%20and%20the%20build%20passes%20today%2C%20but%20the%20declared%20range%20%60%5E4%60%20semantically%20excludes%20v5%2C%20so%20future%20%60pnpm%20install%20--strict-peer-dependencies%60%20runs%20or%20CI%20peer-dep%20checks%20may%20warn%20or%20error%20here.%20It's%20worth%20opening%20a%20compatibility%20issue%20upstream%20or%20pinning%20the%20resolution%20if%20this%20becomes%20a%20problem%20during%20a%20pnpm%20upgrade.%0A%0A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.&repo=wolfstar-project%2Fwolfstar.rocks&uid=108079&ts=1783340817&sig=1beb5aef6381f85078cfbd19c06eb8267c6735779d983e63663ffa950b3618cf&pr=277&platform=github&fid=67bb78e3-dc1b-4a53-b486-c3a29fe2cd4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
nuxt.config.ts:467-479
**Speed Insights beacons blocked by CSP in production**

`nuxt-security` is loaded only in `$production` and enforces the explicit `connect-src` list defined here. `@vercel/speed-insights` reports Web Vitals by sending a `fetch`/`sendBeacon` to `https://vitals.vercel-insights.com`, but that origin is absent from `connect-src`. The browser will silently drop every beacon in production, so the Vercel dashboard will show no Speed Insights data even though the module is installed. A [CSP-related issue in the speed-insights tracker](https://github.com/vercel/speed-insights/issues/103) specifically names this endpoint as required. Add `"https://vitals.vercel-insights.com"` to the `connect-src` array.

### Issue 2 of 2
pnpm-lock.yaml:6234
**`vue-router` peer dependency version mismatch**

The published package metadata for `@vercel/speed-insights@2.0.0` declares `vue-router: ^4` as a peer dependency, but the project resolves `vue-router@5.0.4` (a major bump). pnpm accepted the resolution and the build passes today, but the declared range `^4` semantically excludes v5, so future `pnpm install --strict-peer-dependencies` runs or CI peer-dep checks may warn or error here. It's worth opening a compatibility issue upstream or pinning the resolution if this becomes a problem during a pnpm upgrade.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add @vercel/speed-insights and upd..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/2563b7984e73b129ee6d4d99b4b22d4b26f20c6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42054400)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->