### PR TITLE
ci: add GitHub Actions workflow for canary deployment to beta environment

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1,0 +1,41 @@
+name: Deploy beta
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-beta:
+    if: github.repository == 'wolfstar-project/wolfstar.rocks'
+    name: 🚀 Deploy to beta (beta.wolfstar.rocks)
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 2
+
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
+        with:
+          node-version: lts/*
+          run-install: false
+
+      - uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          # Version of the underlying sfw to use (no `v` prefix): https://github.com/SocketDev/sfw-free/releases
+          firewall-version: 1.12.0
+
+      - run: sfw vp i -g vercel@54.12.2
+      - run: vercel deploy --target=canary
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-beta.yml`: on every push to `main`, deploys to Vercel's `canary` target (`beta.wolfstar.rocks`), replacing the old Railway Dockerfile-based beta deploy now that the app has migrated to Vercel (see #275).
- Uses the project's existing `setup-vp`/Socket firewall-free CI pattern, matching the conventions in the other release workflows.

## Requires (Vercel dashboard / repo secrets)

- `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` repo secrets must be set for this workflow to run.

## Verification

- `pnpm vp run zizmor` ✓ (no findings)

https://claude.ai/code/session_017sTG48MdcAHAmkqEbAQ9tM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to a new GitHub Actions workflow. The workflow follows the repository’s existing CI patterns, uses minimal permissions, pins actions, and scopes deployment to the canonical repository. No functional or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The initial deploy command for beta-zizmor could not run because the zizmor executable was unavailable under /home/user/repo.
- A fallback deploy attempt using npm for zizmor@latest was tried, but it failed with an npm 404; Node v24.18.0 and pnpm 11.3.0 were observed in the environment.
- The Vercel deployment context was inspected and found to have no GITHUB\_\* or VERCEL\_\* environment variables and no local vercel binary, which blocks deployment in the sandbox.

<a href="https://app.greptile.com/trex/runs/13389929/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add GitHub Actions workflow for cana..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/c817129122f5895eba6db077c42910d3bb0146df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42055086)</sub>

<!-- /greptile_comment -->