### PR TITLE
docs: update privacy policy analytics section for self-hosted Umami

### DIFF
--- a/app/pages/(marketing)/privacy.vue
+++ b/app/pages/(marketing)/privacy.vue
@@ -222,12 +222,20 @@
 						Analytics
 					</h2>
 					<p class="mb-4 leading-relaxed text-base-content">
-						We use Vercel Speed Insights to measure page performance (page load speed
-						and Core Web Vitals) and understand how visitors experience our website.
-						This helps us improve performance and identify issues.
+						We use Umami, a privacy-focused analytics platform, to understand how
+						visitors use our website. This helps us improve content, navigation, and the
+						overall experience. Umami runs on our own infrastructure at
+						<NuxtLink
+							to="https://umami.wolfstar.rocks"
+							target="_blank"
+							class="underline hover:opacity-70"
+						>
+							umami.wolfstar.rocks
+						</NuxtLink>
+						.
 					</p>
 					<p class="mb-3 leading-relaxed text-base-content">
-						Vercel Speed Insights is designed with privacy in mind:
+						Umami is designed with privacy in mind:
 					</p>
 					<ul class="list-none space-y-2 pl-0 text-base-content">
 						<li class="flex items-start gap-3 leading-relaxed">
@@ -236,7 +244,7 @@
 						</li>
 						<li class="flex items-start gap-3 leading-relaxed">
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
-							<span>It does not collect personal identifiers or IP addresses</span>
+							<span>It does not collect personal identifiers</span>
 						</li>
 						<li class="flex items-start gap-3 leading-relaxed">
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
@@ -252,16 +260,16 @@
 						<li class="flex items-start gap-3 leading-relaxed">
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
 							<span
-								>Data is measured by a script running in your browser (using native
-								browser performance APIs) and reported directly to Vercel
-							</span>
+								>Analytics are self-hosted, so visitor data stays on infrastructure
+								we control rather than being sent to a third-party analytics
+								vendor</span
+							>
 						</li>
 					</ul>
 					<p class="mt-4 leading-relaxed text-base-content">
-						The only information collected includes: page route/URL, approximate network
-						speed, browser, device type and operating system, country/region, and page
-						performance measurements (Web Vitals). This data cannot be used to identify
-						individual users and is processed by Vercel on our behalf.
+						The only information collected includes: page route/URL, referrer, browser,
+						device type and operating system, and country/region. This data cannot be
+						used to identify individual users.
 					</p>
 				</section>
 
@@ -643,8 +651,9 @@
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
 							<span>
 								<span class="font-semibold">Analytics Data:</span> Retained in
-								anonymous form by Vercel and cannot be linked to individual users.
-								Retained according to Vercel's data retention policy.
+								anonymous form on our self-hosted Umami instance and cannot be
+								linked to individual users. Data is retained until we manually
+								delete it.
 							</span>
 						</li>
 						<li class="flex items-start gap-3 leading-relaxed">


### PR DESCRIPTION
### 🔗 Linked issue

#XXXX

### 🧭 Context

Umami analytics was enabled in production via #281, but the privacy policy still described Vercel Speed Insights. This PR aligns the public-facing documentation with the analytics stack now in use.

### 📚 Description

Updates the **Analytics** and **Data retention** sections of the privacy policy to describe our self-hosted Umami instance (`umami.wolfstar.rocks`) instead of Vercel Speed Insights.

Key points covered:
- Umami is privacy-focused and cookieless
- No personal identifiers or cross-site tracking
- Analytics are self-hosted on infrastructure we control
- Collected metrics: page route/URL, referrer, browser, device/OS, country/region
- Retention on our Umami instance until manually deleted

No runtime or configuration changes — Umami was already wired up in `nuxt.config.ts` on `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to privacy-policy copy, and the referenced Umami host matches the existing Nuxt analytics configuration. No functional, security, or contract issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding.
- T-Rex attempted to validate the privacy UI changes, but the app rendered the Nuxt welcome page instead of the Analytics and Data retention sections, preventing the intended UI verification.

<a href="https://app.greptile.com/trex/runs/13430711/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(privacy): update analytics section ..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/4b8ff9d7dc18b206a5c4b608865ae31bdf0f4c11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42143582)</sub>

<!-- /greptile_comment -->