### PR TITLE
fix(auth): verify OAuth CSRF state before creating the session

### DIFF
--- a/app/pages/oauth/callback.vue
+++ b/app/pages/oauth/callback.vue
@@ -67,6 +67,9 @@ const { error, status, execute } = useFetch("/api/auth/discord", {
 	method: "GET",
 	query: {
 		code,
+		// Sent so the server can verify the CSRF state before exchanging the
+		// code and creating the session.
+		state,
 	},
 	server: false,
 });
@@ -88,9 +91,10 @@ async function performCall() {
 
 	await promiseTimeout(seconds(2));
 
-	// Verify the OAuth state server-side and retrieve the stored redirect URL.
-	// The server reads the nonce + oauth_redirect cookies set during initiation,
-	// verifies the HMAC signature, and returns the safe destination URL.
+	// The CSRF state was already verified by /api/auth/discord before the session
+	// was created (execute() above), so reaching here means the state was valid.
+	// This call consumes the nonce + oauth_redirect cookies to resolve the stored
+	// destination URL and clear them for single use.
 	let redirectUrl = "/";
 	if (state.value) {
 		try {

--- a/server/api/auth/discord.get.ts
+++ b/server/api/auth/discord.get.ts
@@ -2,10 +2,60 @@ import type { APIUser, RESTPostOAuth2AccessTokenResult } from "discord-api-types
 import type { H3Event } from "h3";
 import type { NuxtError } from "nuxt/app";
 import { invalidateCurrentUserCache } from "#server/utils/discord/cache";
-import { createOAuthState } from "#server/utils/oauth-state";
-import { userLogin } from "#shared/audit/actions";
+import { createOAuthState, verifyOAuthState } from "#server/utils/oauth-state";
+import { oauthStateInvalid, userLogin } from "#shared/audit/actions";
 import { isSafeRedirectPath } from "#shared/utils/redirect";
 import { createError, useLogger, withAuditMethods } from "evlog";
+
+/**
+ * Verifies the OAuth CSRF state on the callback request and throws a 400 when
+ * it is missing or invalid.
+ *
+ * This MUST run before the authorization code is exchanged and the session is
+ * created: once `setUserSession` authenticates the browser the mutation cannot
+ * be undone, so an invalid state has to fail the request before that point.
+ * The nonce + redirect cookies are intentionally left in place so the later
+ * `/api/auth/verify-state` call can consume them to resolve the redirect URL.
+ */
+async function assertValidOAuthState(event: H3Event): Promise<void> {
+	const log = withAuditMethods(useLogger(event));
+	const { state } = getQuery(event);
+	const nonce = getCookie(event, "oauth_nonce");
+	const storedRedirectUrl = getCookie(event, "oauth_redirect");
+
+	if (typeof state !== "string" || !nonce || !storedRedirectUrl) {
+		log.audit(
+			oauthStateInvalid({
+				actor: { type: "system", id: "oauth-flow" },
+				outcome: "denied",
+				reason: "missing-fields",
+			}),
+		);
+		throw createError({
+			message: "State verification failed",
+			status: 400,
+			why: "Required parameters (state, nonce, or redirect URL) are missing or invalid",
+			fix: "Restart the login flow from the beginning",
+		});
+	}
+
+	const result = await verifyOAuthState(state, nonce, storedRedirectUrl);
+	if (!result.valid) {
+		log.audit(
+			oauthStateInvalid({
+				actor: { type: "system", id: "oauth-flow" },
+				outcome: "denied",
+				reason: result.reason,
+			}),
+		);
+		throw createError({
+			message: "State verification failed",
+			status: 400,
+			why: "The OAuth state signature is invalid or has expired",
+			fix: "Restart the login flow from the beginning",
+		});
+	}
+}
 
 export default defineWrappedResponseHandler(
 	async (event) => {
@@ -14,10 +64,15 @@ export default defineWrappedResponseHandler(
 
 		const authorizationParams: Record<string, string> = { prompt: "none" };
 
-		// Only generate state + cookies during OAuth initiation (no code present).
-		// When callback.vue calls this endpoint again to exchange the code, we must
-		// NOT overwrite the nonce/redirect cookies set during initiation.
-		if (!query.code) {
+		if (query.code) {
+			// OAuth callback: verify the CSRF state before the code is exchanged
+			// and a session is created (see assertValidOAuthState). The nonce +
+			// redirect cookies set during initiation are reused here.
+			await assertValidOAuthState(event);
+		} else {
+			// OAuth initiation (no code present): generate state + cookies. We must
+			// NOT overwrite the nonce/redirect cookies on the later code-exchange
+			// request, which is why this only runs during initiation.
 			const nextUrl = query.next as string | undefined;
 
 			// Validate next URL — fall back to "/" if unsafe (prevents open redirect)

--- a/server/api/auth/verify-state.get.ts
+++ b/server/api/auth/verify-state.get.ts
@@ -8,7 +8,9 @@ import { createError, useLogger, withAuditMethods } from "evlog";
  *
  * Verifies the signed OAuth CSRF state and returns the stored redirect URL.
  * Reads the nonce and redirect URL from httpOnly cookies set during OAuth
- * initiation, then clears both cookies regardless of outcome.
+ * initiation, then clears both cookies only once the state verifies so a stray
+ * retry or cross-site GET cannot delete the cookies the callback guard in
+ * `/api/auth/discord` still depends on mid-flow.
  *
  * Returns { redirectUrl } on success, or 400 on invalid/missing state.
  */
@@ -18,10 +20,6 @@ export default defineWrappedResponseHandler(
 		const { state } = getQuery(event);
 		const nonce = getCookie(event, "oauth_nonce");
 		const storedRedirectUrl = getCookie(event, "oauth_redirect");
-
-		// Always clear cookies after one use to prevent replay attacks
-		deleteCookie(event, "oauth_nonce", { path: "/" });
-		deleteCookie(event, "oauth_redirect", { path: "/" });
 
 		if (!state || typeof state !== "string" || !nonce || !storedRedirectUrl) {
 			log.audit(
@@ -56,6 +54,14 @@ export default defineWrappedResponseHandler(
 				fix: "Restart the login flow from the beginning",
 			});
 		}
+
+		// Consume the single-use cookies only now that the state has verified.
+		// Clearing them earlier (on any request, before validation) would let a
+		// stray retry or cross-site GET to this endpoint during the OAuth window
+		// delete the cookies the callback guard in /api/auth/discord depends on,
+		// turning a valid in-flight login into a hard 400 failure.
+		deleteCookie(event, "oauth_nonce", { path: "/" });
+		deleteCookie(event, "oauth_redirect", { path: "/" });
 
 		// Re-validate the URL one final time (defence-in-depth against cookie tampering)
 		const redirectUrl = isSafeRedirectPath(storedRedirectUrl) ? storedRedirectUrl : "/";


### PR DESCRIPTION
## Why

The OAuth callback exchanged the authorization code and called `setUserSession` **before** `/api/auth/verify-state` ran. When the state was missing or invalid, the browser had already been authenticated; the later `verify-state` failure only changed the redirect target and could not undo the session mutation. This defeats the CSRF protection the signed state is meant to provide.

## What

State verification now happens in `/api/auth/discord` **before** the code is exchanged, which is the only place that can gate session creation (the session is created inside the provider handler's `onSuccess`). The callback now sends `state` alongside `code`, and an invalid/missing state fails the request with a 400 before any token exchange or `setUserSession` call.

`/api/auth/verify-state` is kept to resolve the stored redirect URL (an httpOnly cookie the client can't read) and to clear the single-use nonce/redirect cookies. It re-verifies as defence in depth. The provider's `onSuccess` is typed `void`, so returning the redirect URL through it would require an unsafe cast; keeping the redirect resolution in `verify-state` avoids that.

The guard, added ahead of the code exchange:

```ts
if (query.code) {
	// Verify CSRF state before the code is exchanged and a session is created.
	await assertValidOAuthState(event);
} else {
	// OAuth initiation: generate signed state + nonce/redirect cookies (unchanged).
}
```

`assertValidOAuthState` reads `state` (query) + `oauth_nonce`/`oauth_redirect` (cookies), audits `oauth.state.invalid` and throws a 400 on missing fields or a failed `verifyOAuthState`, and intentionally leaves the cookies in place for `verify-state` to consume.

## Behaviour change

An invalid or missing OAuth state now blocks sign-in entirely (error UI) instead of authenticating and silently redirecting to `/`. The happy path is unchanged: state is verified, the session is created, and the user is redirected to the stored destination.

## Notes on CI

The recent `ci` failures on `main` and the release PR were all transient Blacksmith cache-upload errors in the `Post Run setup-vp` (cache save) steps (`failed to upload block, non-200 status code`); every build/test/lint/knip work step passed. They are infrastructure, not code, and are not related to this change.

Covered by the existing `verifyOAuthState` unit tests in `test/unit/server/utils/oauth-state.test.ts`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the existing test run for the OAuth-state API and confirmed it completed with exit code 0.
- Validated the added ordering harness test run for the OAuth-state API and confirmed it completed with exit code 0.
- Reviewed the generated TypeScript test code and capture log, including assertions that verifyOAuthState is skipped for missing fields and that defineOAuthDiscordEventHandler and setUserSession are not called on missing or invalid state.
- Linked the four artifacts to the validation so reviewers can inspect the before/after logs, the generated test file, and the corresponding capture log.

<a href="https://app.greptile.com/trex/runs/13447283/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(auth): clear OAuth cookies only afte..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/19953cf37ed51d11f9236c6b2898f3aa63bc1882) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42171778)</sub>

<!-- /greptile_comment -->