### PR TITLE
chore(docs): update AGENTS.md to reflect recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - Add comments only to explain complex logic or non-obvious implementations
 - Write unit tests for core functionality using `vitest`
 - Write end-to-end tests using Playwright and `@nuxt/test-utils`
+- Consolidate component accessibility (axe) assertions into `test/nuxt/a11y.spec.ts` instead of scattering `runAxe()` checks across individual component spec files; keep hydration/behavior tests in the component's own spec file
 - Keep functions focused and manageable (generally under 50 lines)
 - Use error handling patterns consistently
 - Ensure you write strictly type-safe code, for example by ensuring you always check when accessing an array value by index
@@ -36,6 +37,8 @@
 - Routes go under `server/api/` with HTTP suffix (`.get.ts`, `.post.ts`)
 - Always wrap handlers with `defineWrappedResponseHandler` for auth + rate limiting
 - Use `defineWrappedCachedResponseHandler` for cached responses
+- Rate limiting (`server/utils/wrappedEventHandler.ts`) reserves a fixed- or sliding-window quota in storage before the handler runs and rolls the reservation back if the handler throws; it fails open (lets the request through) if the rate-limit storage read/write itself errors
+- Use the `authorize` option (not an inline check in the handler body) for per-request permission checks — e.g. `canManage()` — that must run on every request, including warm cache hits on `defineWrappedCachedResponseHandler` routes
 - Use `createError` for error responses with proper status codes
 - Use the `onError` callback for error logging
 - Validate query strings with shared Valibot schemas from `shared/schemas/` via `getValidatedQuery(event, (body) => parse(Schema, body))`
@@ -49,7 +52,7 @@
 
 ## Auth and Feedback
 
-- Discord OAuth requests the `guilds.members.read` and `email` scopes in `server/api/auth/discord.get.ts`
+- `server/api/auth/discord.get.ts` requests the `guilds.members.read` and `email` scopes and handles both legs of the OAuth flow: with no `code` query param it initiates (sets HMAC-signed nonce/redirect cookies via `createOAuthState()`); with a `code` present it is the callback, which verifies and consumes the CSRF state via `verifyOAuthState()` in `server/utils/oauth-state.ts` **before** any code exchange, then returns `{ redirectUrl }`. There is no separate `verify-state` endpoint — do not reintroduce one
 - The `#auth-utils` `User` type includes `email: string | null`; always handle existing sessions where `user.email` is still `null`
 - Feedback UI uses the custom Sentry feedback flow under `app/components/feedback/`
 - Keep feedback validation in `shared/schemas/feedback.ts` so forms and submit handlers share the same Valibot schema
@@ -81,6 +84,12 @@ pnpm test:perf:prebuilt          # Lighthouse performance checks against an exis
 pnpm test:bench                  # Vitest benchmark suite
 pnpm start:playwright:webserver  # Preview a test build on port 5678 for Playwright
 pnpm audit:verify                # Replay and verify the AuditEvent hash chain
+pnpm design:lint                 # Lint .claude/DESIGN.md with designmd
+pnpm storybook                   # Start Storybook dev server (http://localhost:6006)
+pnpm build-storybook             # Build static Storybook output
+pnpm chromatic                   # Publish Storybook to Chromatic for visual review
+pnpm vp run zizmor               # Lint GitHub Actions workflows for security issues (zizmor)
+pnpm vp run zizmor:fix           # Auto-fix zizmor findings
 pnpm prisma:push                 # Push schema changes (development)
 pnpm prisma:migrate:dev          # Create and apply migration
 pnpm prisma:migrate:dev:create   # Create a migration without applying it
@@ -110,6 +119,7 @@ pnpm update:interactive          # Interactive dependency updates with taze
 - Use `defineWrappedCachedResponseHandler` with `auth: true`, explicit `maxAge`, `swr: false`, `onError`, and route-specific rate limits for log endpoints
 - Validate log route filters with `DashboardActivityQuerySchema`, `CommandLogQuerySchema`, or `ModerationLogQuerySchema` from `shared/schemas/log-queries.ts`
 - Use `resolveGuildMembers()` and `fallbackMember()` from `server/utils/audit/resolve-members.ts` when log rows need Discord member metadata
+- Guild permission checks (`canManage()`) belong in the `authorize` option, not the handler body, so they still run when the response is served from cache
 - Client-side log data access lives in focused composables (`useAuditLog`, `useCommandLog`, `useModerationLog`) that accept `MaybeRefOrGetter` inputs and expose computed `entries` and `total`
 
 ## View Transitions
@@ -156,6 +166,7 @@ Commit messages must follow Conventional Commits: `<type>(<scope>): <subject>`
 - **OAuth redirect fails:** Ensure `.env` `NUXT_OAUTH_DISCORD_REDIRECT_URL` matches Discord Developer Portal exactly
 - **Hot reload broken:** Check file watcher limits on Linux, restart dev server
 - **Type errors after updates:** Run `pnpm nuxt prepare && pnpm prisma:generate`
+- **Duplicate/incompatible `vue` or `discord-api-types` types after a dependency update:** Check the `overrides` in `pnpm-workspace.yaml` still pin a single version of each — two copies make structurally identical (nominally-branded) types incompatible during typecheck
 
 **When in doubt:** Copy existing patterns from similar files (e.g., `server/api/guilds/**`, `app/components/discord/**`) before inventing new ones.
 
@@ -224,7 +235,8 @@ log.audit(
 - `server/utils/audit/resolve-members.ts` — resolves Discord guild members for log display with fallback placeholders
 - `server/plugins/evlog-drain.ts` — routes audit events to the drain
 - `server/plugins/evlog-enrich.ts` — enriches events with UA, trace, and audit context
-- `scripts/audit-verify.ts` — offline hash-chain verifier run with `pnpm audit:verify`
+- `shared/audit/persisted.ts` — reconstructs chain order from `prevHash` linkage (timestamps are not assumed unique) and reports topology problems (forks, cycles, multiple/no roots, unreachable rows, head mismatch) plus hash/link failures
+- `scripts/audit-verify.ts` — offline hash-chain verifier run with `pnpm audit:verify`; loads all `AuditEvent` rows and the `AuditChainHead` row, then delegates to `verifyPersistedAuditChain()` in `shared/audit/persisted.ts`
 
 ### Dashboard Activity Feed
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A — scheduled AGENTS.md maintenance routine.

### 🧭 Context

This is a weekly automated pass that reviews merged PRs and checks `AGENTS.md` for drift against the codebase.

`#283` ("restore Netlify base at d9a206c with Umami analytics") reset `AGENTS.md` to an older baseline as a side effect of restoring an earlier commit, stripping out several sections that documented patterns still present (and in some cases re-added) in the actual code. `#286` ("re-add security boundaries, rate limiting, and audit improvements") restored the underlying source but only fixed one of the doc regressions (the OAuth redirect env var name), leaving the rest of `AGENTS.md` stale. `#285` also landed a real behavior change (OAuth CSRF state is now verified in `discord.get.ts` before the code exchange/session creation) that was never documented.

### 📚 Description

Restored/added to `AGENTS.md`, all verified against the current source:

- **Code Quality Requirements**: re-added the `test/nuxt/a11y.spec.ts` axe-consolidation guidance (confirmed current — no `runAxe()` calls outside that file).
- **Server API Patterns**: re-added the rate-limit reservation/rollback/fail-open behavior of `server/utils/wrappedEventHandler.ts`, and the `authorize` option guidance for permission checks that must run on cache hits.
- **Auth and Feedback**: replaced the stale one-line OAuth description with an accurate description of the current single-endpoint flow in `server/api/auth/discord.get.ts` (initiate vs. callback legs, CSRF state verification via `verifyOAuthState()` before code exchange, no separate `verify-state` endpoint — confirmed that endpoint was deleted in `#286`), reflecting the fix from `#285`.
- **Development Commands**: re-added `design:lint`, `storybook`, `build-storybook`, `chromatic`, and `pnpm vp run zizmor`/`zizmor:fix`, all of which are still valid scripts/tasks in `package.json` and `vite.config.ts` but had been dropped from the docs.
- **Guild Logs and Activity Patterns**: re-added the note that `canManage()` belongs in the `authorize` option so it runs on cached responses too (confirmed current in the guild log routes).
- **Troubleshooting**: re-added the `pnpm-workspace.yaml` `overrides` note for `vue`/`discord-api-types` version pinning (confirmed current).
- **Audit Logging → Key Files**: re-added `shared/audit/persisted.ts` and expanded the `scripts/audit-verify.ts` description to mention it delegates to `verifyPersistedAuditChain()` (confirmed both still exist and match the description).

No other gaps were found — the audit action registry table, Prisma conventions, view-transition docs, and design-token guardrails all still match the codebase.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbCJ6QqYDAteqCdWASKzLA)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge.

The changed file only updates agent guidance, and the added claims match the checked source files, scripts, workspace overrides, and log route patterns.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before evidence, the source grep output was captured to anchor the validation claims.
- A generated validation script named agents\_doc\_consistency\_check.mjs was created and prepared to drive the proof.
- The executed checker produced the after log showing all checks passed, including package scripts, vite-plus tasks, OAuth state ordering, workspace overrides, and audit verifier delegation.

<a href="https://app.greptile.com/trex/runs/13533085/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(docs): update AGENTS.md to reflect..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/1599f6ba921bd0723a1db23d18bdd52331ec9ba2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42343820)</sub>

<!-- /greptile_comment -->