### PR TITLE
chore: migrate badge URLs to shieldcn.dev and update release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Link][invite-link] · [Support Server][discord-link] ·
 
 [![Netlify deploy status badge][netlify-status-shield]][netlify-status-link]
 [![GitHub latest release badge][github-release-shield]][github-release-link]
-[![GitHub release date badge][github-releasedate-shield]][github-releasedate-link]<br/>
+[![GitHub last commit badge][github-last-commit-shield]][github-last-commit-link]<br/>
 [![Discord community badge][discord-shield]][discord-link]
 [![Codecov coverage badge][codecov-shield]][codecov-link]
 [![GitHub contributors badge][github-contributors-shield]][github-contributors-link]<br/>
@@ -358,43 +358,43 @@ Copyright © 2024 [WolfStar][profile-link]. <br /> This project is
   https://github.com/wolfstar-project/.github/blob/main/.github/CONTRIBUTING.md
 [codecov-link]: https://codecov.io/gh/wolfstar-project/wolfstar.rocks
 [codecov-shield]:
-  https://img.shields.io/codecov/c/github/wolfstar-project/wolfstar.rocks?labelColor=black&style=flat-square&logo=codecov&logoColor=white
+  https://shieldcn.dev/codecov/github/wolfstar-project/wolfstar.rocks?variant=branded
 [codespaces-link]: https://codespaces.new/wolfstar-project/wolfstar.rocks
 [codespaces-shield]: https://github.com/codespaces/badge.svg
 [discord-link]: https://join.wolfstar.rocks
 [discord-shield]:
-  https://img.shields.io/discord/830481105261821952?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square
+  https://shieldcn.dev/discord/830481105261821952?variant=branded
 [discord-shield-badge]:
   https://img.shields.io/discord/1127171173982154893?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge
 [github-contributors-link]:
   https://github.com/wolfstar-project/wolfstar.rocks/graphs/contributors
 [github-contributors-shield]:
-  https://img.shields.io/github/contributors/wolfstar-project/wolfstar.rocks?color=c4f042&labelColor=black&style=flat-square
+  https://shieldcn.dev/github/contributors/wolfstar-project/wolfstar.rocks?variant=branded
 [github-forks-link]:
   https://github.com/wolfstar-project/wolfstar.rocks/network/members
 [github-forks-shield]:
-  https://img.shields.io/github/forks/wolfstar-project/wolfstar.rocks?color=8ae8ff&labelColor=black&style=flat-square
+  https://shieldcn.dev/github/forks/wolfstar-project/wolfstar.rocks?variant=branded
 [github-issues-link]: https://github.com/wolfstar-project/wolfstar.rocks/issues
 [github-issues-shield]:
-  https://img.shields.io/github/issues/wolfstar-project/wolfstar.rocks?color=ff80eb&labelColor=black&style=flat-square
+  https://shieldcn.dev/github/issues/wolfstar-project/wolfstar.rocks?variant=branded
 [github-license-link]:
   https://github.com/wolfstar-project/wolfstar.rocks/blob/main/LICENSE
 [github-license-shield]:
-  https://img.shields.io/badge/license-apache%202.0-white?labelColor=black&style=flat-square
+  https://shieldcn.dev/github/license/wolfstar-project/wolfstar.rocks?variant=branded
 [github-project-link]:
   https://github.com/wolfstar-project/wolfstar.rocks/projects
 [github-release-link]:
   https://github.com/wolfstar-project/wolfstar.rocks/releases
 [github-release-shield]:
-  https://img.shields.io/github/v/release/wolfstar-project/wolfstar.rocks?color=369eff&labelColor=black&logo=github&style=flat-square
-[github-releasedate-link]:
-  https://github.com/wolfstar-project/wolfstar.rocks/releases
-[github-releasedate-shield]:
-  https://img.shields.io/github/release-date/wolfstar-project/wolfstar.rocks?labelColor=black&style=flat-square
+  https://shieldcn.dev/github/release/wolfstar-project/wolfstar.rocks?variant=branded
+[github-last-commit-link]:
+  https://github.com/wolfstar-project/wolfstar.rocks/commits
+[github-last-commit-shield]:
+  https://shieldcn.dev/github/last-commit/wolfstar-project/wolfstar.rocks?variant=branded
 [github-stars-link]:
   https://github.com/wolfstar-project/wolfstar.rocks/network/stargazers
 [github-stars-shield]:
-  https://img.shields.io/github/stars/wolfstar-project/wolfstar.rocks?color=ffcb47&labelColor=black&style=flat-square
+  https://shieldcn.dev/github/stars/wolfstar-project/wolfstar.rocks?variant=branded
 [issues-link]:
   https://img.shields.io/github/issues/wolfstar-project/wolfstar.rocks.svg?style=flat
 [netlify-status-shield]:
@@ -405,10 +405,10 @@ Copyright © 2024 [WolfStar][profile-link]. <br /> This project is
 [codspeed-link]:
   https://codspeed.io/wolfstar-project/wolfstar.rocks?utm_source=badge
 [codspeed-shield]:
-  https://img.shields.io/endpoint?url=https://codspeed.io/badge.json
+  https://shieldcn.dev/badge/CodSpeed-benchmarks-blue?variant=branded&logo=codspeed
 [pr-welcome-link]: https://github.com/wolfstar-project/wolfstar.rocks/pulls
 [pr-welcome-shield]:
-  https://img.shields.io/badge/🤯_pr_welcome-%E2%86%92-ffcb47?labelColor=black&style=for-the-badge
+  https://shieldcn.dev/badge/PRs-welcome-ffcb47?variant=branded
 [profile-link]: https://github.com/wolfstar-project
 [share-linkedin-shield]:
   https://img.shields.io/badge/-share%20on%20linkedin-black?labelColor=black&logo=linkedin&logoColor=white&style=flat-square

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Copyright © 2024 [WolfStar][profile-link]. <br /> This project is
 [codspeed-link]:
   https://codspeed.io/wolfstar-project/wolfstar.rocks?utm_source=badge
 [codspeed-shield]:
-  https://shieldcn.dev/badge/CodSpeed-benchmarks-blue?variant=branded&logo=codspeed
+  https://img.shields.io/endpoint?url=https://codspeed.io/badge.json
 [pr-welcome-link]: https://github.com/wolfstar-project/wolfstar.rocks/pulls
 [pr-welcome-shield]:
   https://shieldcn.dev/badge/PRs-welcome-ffcb47?variant=branded


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

This PR updates the README badge infrastructure to use the shieldcn.dev service instead of img.shields.io for most badges, and replaces the release date badge with a last commit badge for more relevant repository activity tracking.

### 📚 Description

**Badge Service Migration:**
- Migrated all GitHub, Discord, and Codecov badges from `img.shields.io` to `shieldcn.dev` with the `variant=branded` parameter for consistent styling
- Updated badge URLs for:
  - Codecov coverage
  - Discord community
  - GitHub contributors, forks, issues, license, release, and stars
  - CodSpeed benchmarks

**Badge Content Update:**
- Replaced `github-releasedate-shield` (release date) with `github-last-commit-shield` (last commit) to provide more meaningful repository activity information
- Updated corresponding link to point to the commits page instead of releases page

**Rationale:**
- Consolidates badge service provider for better maintainability
- Last commit date is a more useful indicator of active development than release date
- shieldcn.dev provides a modern alternative with consistent branding options

All badge functionality remains the same; this is purely a service provider and styling update.

https://claude.ai/code/session_01SfWNE13dsXUtJy3M9fZH6b

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge as a README-only badge update.

The changed file only updates badge image URLs and badge links, with no application code, shared API, or security-boundary impact.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the README badge validation by examining the after-log, confirming each updated shieldcn.dev badge was checked with a status code, content-type, final URL, and a PASS result.
- Verified the GitHub last-commit link in the after-log resolved to the expected URL and returned HTTP 200.
- Compared the after-log with the base checks from the before-log to confirm the baseline and the scope of validation.
- Explained the exact README changes used to scope validation by reviewing the diff-log.

<a href="https://app.greptile.com/trex/runs/13852638/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(readme): restore dynamic CodSpeed b..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/efcc48825a72f8b10fd73d0ec1e46f60773f5710) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43039869)</sub>

<!-- /greptile_comment -->