### PR TITLE
docs: remove analytics documentation from privacy policy

### DIFF
--- a/app/pages/(marketing)/privacy.vue
+++ b/app/pages/(marketing)/privacy.vue
@@ -216,48 +216,6 @@
 					</ul>
 				</section>
 
-				<!-- Analytics -->
-				<section>
-					<h2 class="mb-4 text-lg tracking-wider text-base-content/60 uppercase">
-						Analytics
-					</h2>
-					<p class="mb-4 leading-relaxed text-base-content">
-						We use Netlify Analytics to understand how visitors use our website. This
-						helps us improve the user experience and identify issues.
-					</p>
-					<p class="mb-3 leading-relaxed text-base-content">
-						Netlify Analytics is designed with privacy in mind:
-					</p>
-					<ul class="list-none space-y-2 pl-0 text-base-content">
-						<li class="flex items-start gap-3 leading-relaxed">
-							<span class="shrink-0 text-base-content/50">&mdash;</span>
-							<span>It does not use cookies</span>
-						</li>
-						<li class="flex items-start gap-3 leading-relaxed">
-							<span class="shrink-0 text-base-content/50">&mdash;</span>
-							<span>It does not collect personal identifiers</span>
-						</li>
-						<li class="flex items-start gap-3 leading-relaxed">
-							<span class="shrink-0 text-base-content/50">&mdash;</span>
-							<span>It does not track users across websites</span>
-						</li>
-						<li class="flex items-start gap-3 leading-relaxed">
-							<span class="shrink-0 text-base-content/50">&mdash;</span>
-							<span>All data is aggregated and anonymised</span>
-						</li>
-						<li class="flex items-start gap-3 leading-relaxed">
-							<span class="shrink-0 text-base-content/50">&mdash;</span>
-							<span>Data is collected server-side, not from your browser</span>
-						</li>
-					</ul>
-					<p class="mt-4 leading-relaxed text-base-content">
-						The only information collected includes: page URLs, referrer,
-						country/region, device type, browser, and operating system. This data cannot
-						be used to identify individual users. All analytics data is processed
-						server-side by our hosting provider.
-					</p>
-				</section>
-
 				<!-- Error Tracking -->
 				<section>
 					<h2 class="mb-4 text-lg tracking-wider text-base-content/60 uppercase">
@@ -367,9 +325,8 @@
 						<li class="flex items-start gap-3 leading-relaxed">
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
 							<span>
-								<span class="font-semibold">IP Address:</span> Used for security,
-								rate limiting, and general location (country/region) for analytics.
-								IP addresses are anonymized in analytics and error tracking.
+								<span class="font-semibold">IP Address:</span> Used for security and
+								rate limiting. IP addresses are anonymized in error tracking.
 							</span>
 						</li>
 						<li class="flex items-start gap-3 leading-relaxed">
@@ -635,14 +592,6 @@
 						<li class="flex items-start gap-3 leading-relaxed">
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
 							<span>
-								<span class="font-semibold">Analytics Data:</span> Retained in
-								aggregate form by Netlify and cannot be linked to individual users.
-								Retained according to Netlify's data retention policy.
-							</span>
-						</li>
-						<li class="flex items-start gap-3 leading-relaxed">
-							<span class="shrink-0 text-base-content/50">&mdash;</span>
-							<span>
 								<span class="font-semibold">Error Tracking Data:</span> Retained by
 								Sentry for up to 90 days for debugging purposes, then automatically
 								deleted.
@@ -814,9 +763,9 @@
 						identifies or can be reasonably associated with you. For examples of the
 						precise data points we collect and the sources of such collection, please
 						see the sections above including "INFORMATION WE COLLECT", "WHAT COOKIES DO
-						WE USE", "ANALYTICS", and "ERROR TRACKING AND MONITORING". We collect
-						personal information for the business and commercial purposes described in
-						“OUR USE OF YOUR INFORMATION” above.
+						WE USE", and "ERROR TRACKING AND MONITORING". We collect personal
+						information for the business and commercial purposes described in “OUR USE
+						OF YOUR INFORMATION” above.
 					</p>
 					<p class="mb-4 leading-relaxed text-base-content">
 						<span class="font-semibold">Disclosure of Personal Information</span>: may


### PR DESCRIPTION
Follow-up to #290 (already merged).

#290 removed the analytics integration from the code (`@nuxt/scripts` module, the Umami `scripts` config block, and the `@nuxt/scripts` dependency), but two later commits on that branch (`b78f33b`, `1db7e38`) re-introduced a "Netlify Analytics" section into the privacy policy. Those commits merged into `main`, leaving the policy documenting analytics collection the code no longer performs. Greptile flagged this as a P1 inconsistency.

This reverts the privacy-policy wording to the analytics-removed state so the documentation matches the code:

- Removes the "Analytics" section describing Netlify Analytics data collection
- Restores the "IP Address" entry to security/rate-limiting only (drops the "for analytics" wording)
- Removes the "Analytics Data" retention entry
- Removes "ANALYTICS" from the cross-reference list of documented data practices

Docs-only change; no runtime behavior affected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to documentation text in one Vue page. No runtime code, dependencies, shared interfaces, or security-sensitive paths changed. No issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Rendered the Nuxt /privacy page with Playwright Chromium and captured a post-change screenshot.
- Generated a rendered text dump of the privacy policy page for text-based validation.
- Ran the privacy policy rendering validation and produced a validation log to record checks.
- Collected the dev server log to provide context for the rendering validation.

<a href="https://app.greptile.com/trex/runs/13995084/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: remove analytics documentation fro..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/4013050a01648a4bb6f9a5078a57dc25b558d175) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43322644)</sub>

<!-- /greptile_comment -->