### PR TITLE
revert: restore analytics documentation in privacy policy

### DIFF
--- a/app/pages/(marketing)/privacy.vue
+++ b/app/pages/(marketing)/privacy.vue
@@ -216,6 +216,48 @@
 					</ul>
 				</section>
 
+				<!-- Analytics -->
+				<section>
+					<h2 class="mb-4 text-lg tracking-wider text-base-content/60 uppercase">
+						Analytics
+					</h2>
+					<p class="mb-4 leading-relaxed text-base-content">
+						We use Netlify Analytics to understand how visitors use our website. This
+						helps us improve the user experience and identify issues.
+					</p>
+					<p class="mb-3 leading-relaxed text-base-content">
+						Netlify Analytics is designed with privacy in mind:
+					</p>
+					<ul class="list-none space-y-2 pl-0 text-base-content">
+						<li class="flex items-start gap-3 leading-relaxed">
+							<span class="shrink-0 text-base-content/50">&mdash;</span>
+							<span>It does not use cookies</span>
+						</li>
+						<li class="flex items-start gap-3 leading-relaxed">
+							<span class="shrink-0 text-base-content/50">&mdash;</span>
+							<span>It does not collect personal identifiers</span>
+						</li>
+						<li class="flex items-start gap-3 leading-relaxed">
+							<span class="shrink-0 text-base-content/50">&mdash;</span>
+							<span>It does not track users across websites</span>
+						</li>
+						<li class="flex items-start gap-3 leading-relaxed">
+							<span class="shrink-0 text-base-content/50">&mdash;</span>
+							<span>All data is aggregated and anonymised</span>
+						</li>
+						<li class="flex items-start gap-3 leading-relaxed">
+							<span class="shrink-0 text-base-content/50">&mdash;</span>
+							<span>Data is collected server-side, not from your browser</span>
+						</li>
+					</ul>
+					<p class="mt-4 leading-relaxed text-base-content">
+						The only information collected includes: page URLs, referrer,
+						country/region, device type, browser, and operating system. This data cannot
+						be used to identify individual users. All analytics data is processed
+						server-side by our hosting provider.
+					</p>
+				</section>
+
 				<!-- Error Tracking -->
 				<section>
 					<h2 class="mb-4 text-lg tracking-wider text-base-content/60 uppercase">
@@ -325,8 +367,9 @@
 						<li class="flex items-start gap-3 leading-relaxed">
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
 							<span>
-								<span class="font-semibold">IP Address:</span> Used for security and
-								rate limiting. IP addresses are anonymized in error tracking.
+								<span class="font-semibold">IP Address:</span> Used for security,
+								rate limiting, and general location (country/region) for analytics.
+								IP addresses are anonymized in analytics and error tracking.
 							</span>
 						</li>
 						<li class="flex items-start gap-3 leading-relaxed">
@@ -592,6 +635,14 @@
 						<li class="flex items-start gap-3 leading-relaxed">
 							<span class="shrink-0 text-base-content/50">&mdash;</span>
 							<span>
+								<span class="font-semibold">Analytics Data:</span> Retained in
+								aggregate form by Netlify and cannot be linked to individual users.
+								Retained according to Netlify's data retention policy.
+							</span>
+						</li>
+						<li class="flex items-start gap-3 leading-relaxed">
+							<span class="shrink-0 text-base-content/50">&mdash;</span>
+							<span>
 								<span class="font-semibold">Error Tracking Data:</span> Retained by
 								Sentry for up to 90 days for debugging purposes, then automatically
 								deleted.
@@ -763,9 +814,9 @@
 						identifies or can be reasonably associated with you. For examples of the
 						precise data points we collect and the sources of such collection, please
 						see the sections above including "INFORMATION WE COLLECT", "WHAT COOKIES DO
-						WE USE", and "ERROR TRACKING AND MONITORING". We collect personal
-						information for the business and commercial purposes described in “OUR USE
-						OF YOUR INFORMATION” above.
+						WE USE", "ANALYTICS", and "ERROR TRACKING AND MONITORING". We collect
+						personal information for the business and commercial purposes described in
+						“OUR USE OF YOUR INFORMATION” above.
 					</p>
 					<p class="mb-4 leading-relaxed text-base-content">
 						<span class="font-semibold">Disclosure of Personal Information</span>: may


### PR DESCRIPTION
Reverts commit `a3d63cbf` (originally PR #291, "docs: remove analytics documentation from privacy policy").

This restores the removed content in `app/pages/(marketing)/privacy.vue`:

- The **Analytics** section describing Netlify Analytics and its privacy properties (no cookies, no personal identifiers, no cross-site tracking, aggregated/anonymised, server-side collection).
- The IP Address disclosure wording that mentions general location for analytics and anonymization in analytics.
- The **Analytics Data** retention entry (aggregate form via Netlify).
- The "ANALYTICS" reference in the CCPA/summary section.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786350015&installation_id=142944007&pr_number=292&repository=wolfstar-project%2Fwolfstar.rocks&return_to=https%3A%2F%2Fgithub.com%2Fwolfstar-project%2Fwolfstar.rocks%2Fpull%2F292&signature=4c6d1d568b99f2970c1837f2d737550d5b0fc521ada6f8aed83d70f84517bfe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal implementation risk.

The change only restores static privacy-policy text and does not modify runtime behavior, dependencies, data collection code, or shared interfaces.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Nuxt prepare step completed successfully with exit code 0 during the privacy build.
- An attempt to start the real app command was blocked by a stale node\_modules state, with guidance to run pnpm i.
- The analytics checks against HEAD^ all failed before applying the page source changes.
- After updating the privacy page source, all six analytics checks passed against the current source.

<a href="https://app.greptile.com/trex/runs/14080863/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;docs: remove analytics documenta..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/98a0f8ab65c5bf66224c3d0ab4b538a7bb71ea1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43487889)</sub>

<!-- /greptile_comment -->