### PR TITLE
fix(ui): shrink oversized avatar size scale

### DIFF
--- a/app/themes/avatar.ts
+++ b/app/themes/avatar.ts
@@ -20,20 +20,32 @@ export default {
 			},
 		},
 		size: {
-			lg: {
-				root: "size-12",
+			"3xs": {
+				root: "size-4 text-[8px]",
 			},
-			md: {
-				root: "size-10",
+			"2xs": {
+				root: "size-5 text-[10px]",
 			},
-			sm: {
-				root: "size-8",
+			"xs": {
+				root: "size-6 text-xs",
 			},
-			xl: {
-				root: "size-14",
+			"sm": {
+				root: "size-7 text-sm",
 			},
-			xs: {
-				root: "size-6",
+			"md": {
+				root: "size-8 text-base",
+			},
+			"lg": {
+				root: "size-9 text-lg",
+			},
+			"xl": {
+				root: "size-10 text-xl",
+			},
+			"2xl": {
+				root: "size-11 text-[22px]",
+			},
+			"3xl": {
+				root: "size-12 text-2xl",
 			},
 		},
 		status: {

--- a/app/themes/avatar.ts
+++ b/app/themes/avatar.ts
@@ -21,19 +21,19 @@ export default {
 		},
 		size: {
 			lg: {
-				root: "size-24",
+				root: "size-12",
 			},
 			md: {
-				root: "size-16",
-			},
-			sm: {
 				root: "size-10",
 			},
+			sm: {
+				root: "size-8",
+			},
 			xl: {
-				root: "size-32",
+				root: "size-14",
 			},
 			xs: {
-				root: "size-8",
+				root: "size-6",
 			},
 		},
 		status: {


### PR DESCRIPTION
The avatar theme mapped lg to size-24 (96px) and md to size-16 (64px),
far larger than the 40px skeleton placeholder shown alongside it and
every other avatar usage in the app, causing user avatars in
guild/audit tables to render far too large.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to shared `UAvatar` theme sizing and matches the affected table-avatar usage paths reviewed.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The temporary validation route was set up and inspected to render the UAvatar next to a 40px reference.
- A Playwright capture script named trex\_avatar\_capture.mjs was saved to automate the validation checks.
- Nuxt logs showed the dev server compiling Nuxt UI CSS and serving the validation route.
- Browser capture attempts faced an initial path mismatch and later timeouts, making measurements stale and unreliable.

<a href="https://app.greptile.com/trex/runs/14083915/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(theme): align avatar size scale with..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/458da768e1a5f1a671295fd3b263371c1fe66cc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43495740)</sub>

<!-- /greptile_comment -->