### PR TITLE
chore(docs): update AGENTS.md to reflect recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@
 - Block order: template -> script -> script setup -> styles
 - Never create reactive state at module scope; use composables in `app/composables/`
 - Place feature-specific components in grouped directories once a feature has multiple pieces, e.g. feedback UI in `app/components/feedback/`
+- In guild-settings `mapToGuildData()`/`calculateChanges()` functions, assign values onto `Partial<GuildData>` with `setGuildDataChange()` from `#shared/utils/guild-settings-map` instead of an `as any`/`as never` cast — it skips `undefined` so untouched keys stay out of PATCH payloads while keeping key/value types checked
 
 ## Auth and Feedback
 


### PR DESCRIPTION
### 🧭 Context

Weekly review of PRs merged into `main` since the last AGENTS.md maintenance pass (#287, merged 2026-07-07).

### 📚 Description

Reviewed #286, #289, #290, #291, #292, and #293. Most of #286's documentation-relevant changes (the OAuth redirect env var name, removal of the `verify-state` endpoint, the `pnpm-workspace.yaml` `overrides` note) were already captured in AGENTS.md by prior updates. The remaining gap: #286 introduced `setGuildDataChange()` in `shared/utils/guild-settings-map.ts` as the new pattern for building `Partial<GuildData>` changes in guild-settings `mapToGuildData()`/`calculateChanges()` functions, replacing `as any`/`as never` casts. It's now used consistently across `Channels.vue`, `Roles.vue`, `Moderation.vue`, `Events.vue`, and `Form.vue`, but wasn't mentioned in AGENTS.md's Vue Component Patterns section.

Added one bullet documenting this pattern. #289 (badge URLs), #290–#292 (analytics/privacy policy churn), and #293 (avatar theme sizing) didn't touch anything architecturally relevant to AGENTS.md.

No other gaps found — `CLAUDE.md` is a symlink to `AGENTS.md`, so both stay in sync automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_011hwG87ChE3QcKuLDa1VRJ4)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge.

The added guidance matches the existing `setGuildDataChange()` helper behavior and does not change runtime code.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured the baseline docs state as the before log to establish the pre-verification baseline.
- T-Rex ran the after verification commands and confirmed exit code 0, validating multiple checks including AGENTS.md line 52, helper export line 7, usage across all named components, and CLAUDE.md/GEMINI.md symlink checks.
- T-Rex generated the verify-docs-guild-settings.sh script for the after proof.

<a href="https://app.greptile.com/trex/runs/14177277/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(docs): update AGENTS.md to reflect..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/5888500a2ebd4214d3c74231821436287a665aab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43693162)</sub>

<!-- /greptile_comment -->