### PR TITLE
fix(ui): stack avatar above username and enlarge it

### DIFF
--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -3,7 +3,7 @@
 	<UContainer class="mx-auto max-w-7xl space-y-8 px-4 py-8">
 		<h1 class="sr-only">User Profile</h1>
 		<section
-			class="relative flex flex-col items-center justify-center gap-6 overflow-hidden rounded-xl border-2 border-base-200 bg-base-200/30 p-8 md:flex-row md:border-4 md:p-12"
+			class="relative flex flex-col items-center justify-center gap-6 overflow-hidden rounded-xl border-2 border-base-200 bg-base-200/30 p-8 md:border-4 md:p-12"
 			aria-label="User profile"
 		>
 			<!-- decorative left accent (sidebar-like) -->
@@ -13,7 +13,7 @@
 			></div>
 			<div v-if="!user" class="flex flex-col items-center justify-center space-y-6">
 				<USkeleton
-					class="h-24 w-24 rounded-full ring-2 ring-base-200 ring-offset-4 ring-offset-base-100"
+					class="h-32 w-32 rounded-full ring-2 ring-base-200 ring-offset-4 ring-offset-base-100 md:h-40 md:w-40"
 				/>
 				<div class="space-y-2 text-center">
 					<USkeleton class="h-10 w-48" />
@@ -27,7 +27,7 @@
 			<template v-else>
 				<div class="avatar" :class="{ 'avatar-placeholder': isDefault }">
 					<div
-						class="flex items-center justify-center rounded-full ring-base-300 ring-offset-base-100"
+						class="flex h-32 w-32 shrink-0 items-center justify-center rounded-full ring-base-300 ring-offset-base-100 md:h-40 md:w-40"
 						:class="{
 							'transition-transform duration-300 group-hover:scale-105':
 								!effectiveReduceMotion,
@@ -38,8 +38,8 @@
 							:src="defaultAvatar"
 							alt="Default Avatar"
 							class="h-full w-full object-cover"
-							:width="128"
-							:height="128"
+							:width="160"
+							:height="160"
 							format="png"
 							loading="lazy"
 							decoding="async"
@@ -49,9 +49,9 @@
 							v-else
 							:src="createUrl(preferredFormat, 256)"
 							:format="preferredFormat === 'gif' ? undefined : 'webp'"
-							:width="128"
-							:height="128"
-							sizes="128px"
+							:width="160"
+							:height="160"
+							sizes="(min-width: 768px) 160px, 128px"
 							:alt="`${user?.globalName ?? user?.username} avatar`"
 							class="h-full w-full object-cover"
 							loading="lazy"


### PR DESCRIPTION
The profile header used md:flex-row with no explicit avatar size,
so on medium widths the avatar sat beside the name and got
flex-shrunk small. Keep the header stacked at all breakpoints and
give the avatar a fixed, larger size (128px, 160px on desktop) so
it no longer shrinks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to profile page presentation classes and Nuxt image dimensions. No data flow, authentication, shared interfaces, or security-sensitive paths changed.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex collected evidence artifacts from the run, including logs and Playwright screenshots/videos of the startup.
- The medium viewport /profile capture shows Nuxt Welcome content, indicating the real profile page did not render during this run.
- No PR-related avatar/header layout proof was confirmed; the result is inconclusive due to environment/app startup blockers.

<a href="https://app.greptile.com/trex/runs/14672695/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(profile): stack avatar above usernam..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/c6fa45a29485cc7a025d0645fa1073410818f173) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44744995)</sub>

<!-- /greptile_comment -->