### PR TITLE
fix(ui): remove duplicate mobile Discord button and improve drawer UX

### DIFF
--- a/app/components/app/Header.vue
+++ b/app/components/app/Header.vue
@@ -26,34 +26,24 @@
 		</div>
 
 		<template #right>
-			<div class="flex items-center gap-2">
+			<div class="hidden items-center gap-2 md:flex">
 				<UButton
 					v-if="currentApp.invite !== '#'"
 					label="Add App"
 					size="sm"
 					color="primary"
 					:to="currentApp.invite"
-					class="hidden rounded-lg font-semibold md:inline-flex"
+					class="rounded-lg font-semibold"
 				/>
 				<ClientOnly>
 					<LazyAppHeaderAuth />
 					<template #fallback>
 						<UButton
-							size="md"
-							color="primary"
-							variant="subtle"
-							block
-							class="invisible md:hidden"
-							icon="ic:round-discord"
-							tabindex="-1"
-						/>
-						<UButton
 							label="Sign in"
 							size="md"
 							color="primary"
 							variant="subtle"
-							block
-							class="invisible hidden md:inline-flex"
+							class="invisible rounded-lg"
 							icon="ic:round-discord"
 							tabindex="-1"
 						/>
@@ -62,30 +52,46 @@
 			</div>
 		</template>
 		<template #body>
-			<UNavigationMenu
-				orientation="vertical"
-				:items="mobileLinks"
-				class="-mx-2.5"
-				aria-label="Mobile navigation"
-			/>
+			<nav class="flex min-h-0 flex-1 flex-col gap-6" aria-label="Mobile menu">
+				<UNavigationMenu
+					orientation="vertical"
+					:items="mobileLinks"
+					class="-mx-1"
+					aria-label="Mobile navigation"
+					:ui="{
+						link: 'rounded-lg px-3 py-3 text-base font-medium',
+						childLink: 'rounded-lg px-3 py-2.5 text-sm',
+						childList: 'ms-2 border-s border-default ps-2',
+					}"
+				/>
 
-			<Separator class="my-6" />
-
-			<ClientOnly>
-				<LazyAppHeaderAuth mobile />
-				<template #fallback>
+				<div class="mt-auto flex flex-col items-center gap-3 border-t border-default pt-5">
 					<UButton
-						label="Sign in"
+						v-if="currentApp.invite !== '#'"
+						label="Add App"
 						size="md"
 						color="primary"
-						variant="subtle"
-						block
-						class="invisible"
-						icon="ic:round-discord"
-						tabindex="-1"
+						:to="currentApp.invite"
+						class="rounded-lg font-semibold"
 					/>
-				</template>
-			</ClientOnly>
+					<ClientOnly>
+						<LazyAppHeaderAuth mobile />
+						<template #fallback>
+							<div class="flex justify-center">
+								<UButton
+									label="Sign in"
+									size="md"
+									color="primary"
+									variant="subtle"
+									class="invisible rounded-lg"
+									icon="ic:round-discord"
+									tabindex="-1"
+								/>
+							</div>
+						</template>
+					</ClientOnly>
+				</div>
+			</nav>
 		</template>
 	</UHeader>
 </template>

--- a/app/components/app/HeaderAuth.vue
+++ b/app/components/app/HeaderAuth.vue
@@ -36,35 +36,28 @@
 					</div>
 				</LazyUDropdownMenu>
 			</div>
-			<div v-else>
-				<UButton
-					v-if="!mobile"
-					size="md"
-					color="primary"
-					variant="subtle"
-					to="/login"
-					block
-					class="md:hidden"
-					icon="ic:round-discord"
-					aria-label="Sign in with Discord"
-				/>
+			<div v-else :class="mobile ? 'flex justify-center' : undefined">
 				<UButton
 					label="Sign in"
 					size="md"
 					color="primary"
 					variant="subtle"
 					to="/login"
-					block
-					:class="mobile ? undefined : 'hidden md:inline-flex'"
+					:class="mobile ? 'rounded-lg' : 'hidden rounded-lg md:inline-flex'"
 					icon="ic:round-discord"
 					aria-label="Sign in with Discord"
 				/>
 			</div>
 		</template>
 		<template #placeholder>
-			<div class="flex items-center gap-2">
-				<USkeleton class="size-6 rounded-full" />
-				<USkeleton class="h-4 w-16" :class="mobile ? undefined : 'hidden sm:block'" />
+			<div class="flex items-center gap-2" :class="mobile ? 'justify-center' : undefined">
+				<template v-if="mobile">
+					<USkeleton class="h-10 w-36 rounded-lg" />
+				</template>
+				<template v-else>
+					<USkeleton class="size-6 rounded-full" />
+					<USkeleton class="hidden h-4 w-16 sm:block" />
+				</template>
 			</div>
 		</template>
 	</BetterAuthState>
@@ -74,7 +67,7 @@
 import type { DropdownMenuItem } from "@nuxt/ui";
 
 const { mobile = false } = defineProps<{
-	/** Renders a full-width variant suited for the mobile navigation drawer. */
+	/** Renders a drawer-friendly variant for the mobile navigation panel. */
 	mobile?: boolean;
 }>();
 

--- a/app/composables/useHeader.ts
+++ b/app/composables/useHeader.ts
@@ -65,13 +65,19 @@ export function useHeader() {
 		{
 			children: [
 				{
+					description: "Tools to help you moderate your server",
 					label: "Moderation Tools",
+					to: "#moderation-tools",
 				},
 				{
+					description: "Track and log events in your server",
 					label: "Advanced Logging",
+					to: "#advanced-logging",
 				},
 				{
+					description: "Searchable moderation history for every action",
 					label: "Moderation Logs",
+					to: "#moderation-logs",
 				},
 			],
 			label: "Features",

--- a/test/nuxt/components/app/HeaderAuth.spec.ts
+++ b/test/nuxt/components/app/HeaderAuth.spec.ts
@@ -21,4 +21,24 @@ describe("AppHeaderAuth", () => {
 			expect(second.html()).toBe(first.html());
 		});
 	});
+
+	describe("responsive sign-in", () => {
+		it("hides the header sign-in control below md breakpoints", async () => {
+			const wrapper = await mountSuspended(AppHeaderAuth);
+			const button = wrapper.get('a[aria-label="Sign in with Discord"]');
+			expect(button.classes().join(" ")).toContain("hidden");
+			expect(button.classes().join(" ")).toContain("md:inline-flex");
+			expect(button.classes().join(" ")).not.toContain("w-full");
+		});
+
+		it("renders a compact non-block sign-in control in the mobile drawer", async () => {
+			const wrapper = await mountSuspended(AppHeaderAuth, {
+				props: { mobile: true },
+			});
+			const button = wrapper.get('a[aria-label="Sign in with Discord"]');
+			expect(button.classes().join(" ")).toContain("rounded-lg");
+			expect(button.classes().join(" ")).not.toContain("w-full");
+			expect(button.attributes("href")).toBe("/login");
+		});
+	});
 });

--- a/test/nuxt/composables/useHeader.spec.ts
+++ b/test/nuxt/composables/useHeader.spec.ts
@@ -64,4 +64,12 @@ describe("useHeader", () => {
 		const labels = mobileLinks.value.map((l: any) => l.label);
 		expect(labels).toContain("GitHub");
 	});
+
+	it("should give Features children destinations on mobile", async () => {
+		const { mobileLinks } = await setup();
+		const features = mobileLinks.value.find((l: any) => l.label === "Features");
+		expect(features?.children?.every((child: any) => typeof child.to === "string")).toBe(
+			true,
+		);
+	});
 });

--- a/test/nuxt/composables/useHeader.spec.ts
+++ b/test/nuxt/composables/useHeader.spec.ts
@@ -68,8 +68,6 @@ describe("useHeader", () => {
 	it("should give Features children destinations on mobile", async () => {
 		const { mobileLinks } = await setup();
 		const features = mobileLinks.value.find((l: any) => l.label === "Features");
-		expect(features?.children?.every((child: any) => typeof child.to === "string")).toBe(
-			true,
-		);
+		expect(features?.children?.every((child: any) => typeof child.to === "string")).toBe(true);
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Hide header Sign in / Add App controls below `md` so the open mobile menu no longer shows a duplicate Discord icon next to the close button
- Replace the full-width elongated Sign in button with a compact `rounded-lg` control in the mobile drawer
- Improve mobile menu UX: larger tap targets, clearer nested link hierarchy, sticky action footer, Add App CTA, and working Features destinations

## Test plan
- [ ] Open the site on a narrow viewport and open the hamburger menu
- [ ] Confirm only the close (X) control appears in the top-right (no Discord icon)
- [ ] Confirm Sign in is compact (not a full-width pill)
- [ ] Confirm Features / Applications children are tappable and Add App appears when an invite URL exists
- [ ] Confirm desktop header still shows Add App + Sign in from `md` up

## Verification
- `pnpm lint:fix` — clean
- `pnpm typecheck` — pass
- `pnpm test:unit` — pass
- Header-related Nuxt tests — 12/12 pass
- `pnpm build` — pass (with test secrets + site URL)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78ce38ea-89cb-419b-a81a-5e5fc6381124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78ce38ea-89cb-419b-a81a-5e5fc6381124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Feature navigation from non-WolfStar routes needs a fix before merging.

The new hash-only links work on the WolfStar landing page. The shared header also exposes them on pages without the target elements, where they do not navigate or scroll. No security issues were found in the changed code.

app/composables/useHeader.ts
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted a production-build verification, which was blocked when the build terminated with exit code 137 and failed to produce Nuxt server output.
- A bounded Nuxt development-server fallback was started and polled twelve times but never became reachable at /staryl due to resource exhaustion from concurrent repository build and development processes.
- T-Rex completed the verification pass but reported that its local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/15416423/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fcomposables%2FuseHeader.ts%3A70%0A**Hash%20Links%20Retain%20Wrong%20Route**%0A%0AThe%20shared%20header%20appears%20on%20routes%20such%20as%20%60%2Fstaryl%60%2C%20%60%2Fblog%60%2C%20and%20%60%2Flogin%60%2C%20but%20%60to%3D%22%23moderation-tools%22%60%20retains%20the%20current%20pathname.%20Those%20pages%20do%20not%20contain%20this%20section%2C%20so%20tapping%20the%20new%20menu%20item%20changes%20only%20the%20hash%20and%20does%20not%20navigate%20or%20scroll%20to%20the%20requested%20feature%3B%20the%20three%20links%20should%20include%20the%20WolfStar%20route.%0A%0A&repo=wolfstar-project%2Fwolfstar.rocks&pr=309&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fcomposables%2FuseHeader.ts%3A70%0A**Hash%20Links%20Retain%20Wrong%20Route**%0A%0AThe%20shared%20header%20appears%20on%20routes%20such%20as%20%60%2Fstaryl%60%2C%20%60%2Fblog%60%2C%20and%20%60%2Flogin%60%2C%20but%20%60to%3D%22%23moderation-tools%22%60%20retains%20the%20current%20pathname.%20Those%20pages%20do%20not%20contain%20this%20section%2C%20so%20tapping%20the%20new%20menu%20item%20changes%20only%20the%20hash%20and%20does%20not%20navigate%20or%20scroll%20to%20the%20requested%20feature%3B%20the%20three%20links%20should%20include%20the%20WolfStar%20route.%0A%0A&pr=309&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22wolfstar-project%2Fwolfstar.rocks%22%20on%20the%20existing%20branch%20%22cursor%2Ffix-mobile-header-nav-1124%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Ffix-mobile-header-nav-1124%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fcomposables%2FuseHeader.ts%3A70%0A**Hash%20Links%20Retain%20Wrong%20Route**%0A%0AThe%20shared%20header%20appears%20on%20routes%20such%20as%20%60%2Fstaryl%60%2C%20%60%2Fblog%60%2C%20and%20%60%2Flogin%60%2C%20but%20%60to%3D%22%23moderation-tools%22%60%20retains%20the%20current%20pathname.%20Those%20pages%20do%20not%20contain%20this%20section%2C%20so%20tapping%20the%20new%20menu%20item%20changes%20only%20the%20hash%20and%20does%20not%20navigate%20or%20scroll%20to%20the%20requested%20feature%3B%20the%20three%20links%20should%20include%20the%20WolfStar%20route.%0A%0A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.&repo=wolfstar-project%2Fwolfstar.rocks&uid=108079&ts=1784732800&sig=86f8febe3d7c7268bf23f9b17c7bdf8eaa828095386819307889691a7b806614&pr=309&platform=github&fid=0e3eeeba-6cc0-4912-ae4c-f75cfad4f8dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
app/composables/useHeader.ts:70
**Hash Links Retain Wrong Route**

The shared header appears on routes such as `/staryl`, `/blog`, and `/login`, but `to="#moderation-tools"` retains the current pathname. Those pages do not contain this section, so tapping the new menu item changes only the hash and does not navigate or scroll to the requested feature; the three links should include the WolfStar route.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/wolfstar-project/wolfstar.rocks/commit/a8810c724f82773cc6c3d911c4021dd0a9f8bd71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46321922)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->