### PR TITLE
fix(ui): route header feature links to WolfStar page

### DIFF
--- a/app/composables/useHeader.ts
+++ b/app/composables/useHeader.ts
@@ -19,17 +19,17 @@ export function useHeader() {
 				{
 					description: t("nav.moderation_tools_description"),
 					label: t("nav.moderation_tools"),
-					to: "#moderation-tools",
+					to: "/wolfstar#moderation-tools",
 				},
 				{
 					description: t("nav.advanced_logging_description"),
 					label: t("nav.advanced_logging"),
-					to: "#advanced-logging",
+					to: "/wolfstar#advanced-logging",
 				},
 				{
 					description: t("nav.moderation_logs_description"),
 					label: t("nav.moderation_logs"),
-					to: "#moderation-logs",
+					to: "/wolfstar#moderation-logs",
 				},
 			],
 			label: t("nav.features"),
@@ -69,17 +69,17 @@ export function useHeader() {
 				{
 					description: t("nav.moderation_tools_description"),
 					label: t("nav.moderation_tools"),
-					to: "#moderation-tools",
+					to: "/wolfstar#moderation-tools",
 				},
 				{
 					description: t("nav.advanced_logging_description"),
 					label: t("nav.advanced_logging"),
-					to: "#advanced-logging",
+					to: "/wolfstar#advanced-logging",
 				},
 				{
 					description: t("nav.moderation_logs_description"),
 					label: t("nav.moderation_logs"),
-					to: "#moderation-logs",
+					to: "/wolfstar#moderation-logs",
 				},
 			],
 			label: t("nav.features"),


### PR DESCRIPTION
The header's Features menu links used bare hash targets (`#moderation-tools`, `#advanced-logging`, `#moderation-logs`). The shared header renders on every route (`/staryl`, `/blog`, `/login`, guild pages, etc.), but those anchor sections only exist on the WolfStar landing page (`app/pages/(marketing)/wolfstar/index.vue`, aliased to `/`). On any other route, tapping a Features item only mutated the URL hash without navigating or scrolling anywhere.

This prefixes all six links (desktop + mobile) with the WolfStar route so they navigate to the page that actually contains the sections, then scroll to the anchor:

```ts
// app/composables/useHeader.ts
{ label: "Moderation Tools", to: "/wolfstar#moderation-tools" },
{ label: "Advanced Logging", to: "/wolfstar#advanced-logging" },
{ label: "Moderation Logs",  to: "/wolfstar#moderation-logs" },
```

The target `<div :id="feature.id" class="scroll-mt-24">` anchors already exist in `ModerationShowcase.vue`, so hash scrolling resolves correctly.

Follow-up to #309 (already merged), addressing the greptile review comment that the merge did not cover.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is limited to static header link targets. The `/wolfstar` route exists and the referenced section IDs are present on the WolfStar marketing page. No functional or security issues were identified.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the Playwright desktop Features navigation script header-features-nav.spec.mjs, which would exercise the requested Features click flow against the internal URL.
- Confirmed that header-features-nav-build.log shows a build:test run started but did not complete and includes a sitemap URL error from the build process.
- Investigated server and probe traces and found /staryl returning HTTP 500 due to connect ENOENT nuxt.sock, as shown in the server log, preview probe log, and the 500 response artifact.

<a href="https://app.greptile.com/trex/runs/16437679/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): route header feature links to W..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/32c10484ffdc0cd69c9507d5c0a4f11c4373cda5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47112977)</sub>

<!-- /greptile_comment -->