### PR TITLE
ci: right-size 5 runners for faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
   test:
     name: 🧪 Component tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -147,7 +147,7 @@ jobs:
 
   browser:
     name: 🖥️ Browser tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     container:
       image: mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48
 
@@ -209,7 +209,7 @@ jobs:
 
   a11y:
     name: ♿ Accessibility audit
-    runs-on: blacksmith-4vcpu-ubuntu-2404 # See https://github.com/GoogleChrome/lighthouse/discussions/16834
+    runs-on: blacksmith-8vcpu-ubuntu-2404 # See https://github.com/GoogleChrome/lighthouse/discussions/16834
     strategy:
       matrix:
         mode: [dark, light]
@@ -241,7 +241,7 @@ jobs:
 
   perf:
     name: ⚡ Performance
-    runs-on: blacksmith-4vcpu-ubuntu-2404 # See https://github.com/GoogleChrome/lighthouse/discussions/16834
+    runs-on: blacksmith-8vcpu-ubuntu-2404 # See https://github.com/GoogleChrome/lighthouse/discussions/16834
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Right-sizes 5 CPU-bound jobs in `.github/workflows/ci.yml` up to 8 vCPU. All five run pinned at ~99-100% CPU with every core saturated on the current 4 vCPU runners, so they are CPU-starved and finishing slower than they need to. Doubling the runner cuts each one's wall time by roughly 37-39% for a modest per-run cost increase (~$17/month more across all five combined).

Note: the two Accessibility audit rows (dark and light) are a single matrixed `a11y` job, so both are covered by the one `runs-on:` change on that job.

```yaml
# .github/workflows/ci.yml
  test:      # 🧪 Component tests
    runs-on: blacksmith-8vcpu-ubuntu-2404-arm   # was 4vcpu-arm
  browser:   # 🖥️ Browser tests
    runs-on: blacksmith-8vcpu-ubuntu-2404-arm   # was 4vcpu-arm
  a11y:      # ♿ Accessibility audit (dark + light matrix)
    runs-on: blacksmith-8vcpu-ubuntu-2404       # was 4vcpu
  perf:      # ⚡ Performance
    runs-on: blacksmith-8vcpu-ubuntu-2404       # was 4vcpu
```

## Apply for speed

### ⚡ Performance (`perf`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-8vcpu-ubuntu-2404`
High confidence. Average CPU is 88% with 95th and 99th percentile CPU pinned at 100% across 480 runs/month, saturating all 4 cores. Projected wall-time change ~-39% (p50 -40%, p95 -36%): p50 ~211s -> ~127s, p95 ~360s -> ~231s. Runtime-adjusted spend ~$16.27 -> ~$19.73/month (+$3.46).
Samples: [median run](https://app.blacksmith.sh/wolfstar-project/runs/28746160228/jobs/85237307695?tab=metrics) - [slow run (p95)](https://app.blacksmith.sh/wolfstar-project/runs/29535094276/jobs/87744477692?tab=metrics)

### ♿ Accessibility audit - dark (`a11y`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-8vcpu-ubuntu-2404`
High confidence. Average CPU is 88% with 95th percentile CPU near 100% and all cores saturated across 481 runs/month. Projected wall-time change ~-39% (p50 -40%, p95 -36%): p50 ~200s -> ~120s, p95 ~342s -> ~219s. Runtime-adjusted spend ~$15.39 -> ~$18.65/month (+$3.26).
Samples: [median run](https://app.blacksmith.sh/wolfstar-project/runs/29707557156/jobs/88246965088?tab=metrics) - [slow run (p95)](https://app.blacksmith.sh/wolfstar-project/runs/29489119918/jobs/87590661122?tab=metrics)

### ♿ Accessibility audit - light (`a11y`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-8vcpu-ubuntu-2404`
High confidence. Average CPU is 87% with 95th and 99th percentile CPU at 100% across 481 runs/month, saturating all cores. Projected wall-time change ~-38% (p50 -39%, p95 -35%): p50 ~203s -> ~124s, p95 ~330s -> ~215s. Runtime-adjusted spend ~$15.22 -> ~$18.82/month (+$3.60).
Samples: [median run](https://app.blacksmith.sh/wolfstar-project/runs/28758253690/jobs/85268909050?tab=metrics) - [slow run (p95)](https://app.blacksmith.sh/wolfstar-project/runs/28974084113/jobs/85976751202?tab=metrics)

_The dark and light audits share the one `a11y` `runs-on:` line above; both are applied by this single change._

### 🧪 Component tests (`test`): `blacksmith-4vcpu-ubuntu-2404-arm` -> `blacksmith-8vcpu-ubuntu-2404-arm`
High confidence. Average CPU is 86% with 95th percentile at 99.7% and all 4 cores saturated across 481 runs/month. Projected wall-time change ~-38% (p50 -38%, p95 -35%): p50 ~283s -> ~174s, p95 ~472s -> ~309s. Runtime-adjusted spend ~$12.82 -> ~$15.92/month (+$3.10).
Samples: [median run](https://app.blacksmith.sh/wolfstar-project/runs/28758253690/jobs/85268909044?tab=metrics) - [slow run (p95)](https://app.blacksmith.sh/wolfstar-project/runs/29917088464/jobs/88913385652?tab=metrics)

## Test before applying

### 🖥️ Browser tests (`browser`): `blacksmith-4vcpu-ubuntu-2404-arm` -> `blacksmith-8vcpu-ubuntu-2404-arm`
Medium confidence. 95th percentile CPU sits at 99.6% with average CPU at 82% across 478 runs/month, all 4 cores saturated at peak, so the job is CPU-starved. Projected wall-time change ~-37% (p50 -38%, p95 -34%): p50 ~349s -> ~217s, p95 ~609s -> ~403s. Runtime-adjusted spend ~$15.66 -> ~$19.69/month (+$4.03). This job runs in a Playwright container, so confirm the speedup holds on the larger runner.
Samples: [median run](https://app.blacksmith.sh/wolfstar-project/runs/29827768588/jobs/88624985223?tab=metrics) - [slow run (p95)](https://app.blacksmith.sh/wolfstar-project/runs/29437429197/jobs/87427493750?tab=metrics)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to four runner-size labels and does not alter any build steps, test logic, or workflow structure.

All four changes are isolated `runs-on:` label swaps backed by measured CPU-saturation data. The ARM/x86 split is preserved correctly, and the existing Lighthouse comment is carried over unchanged. The only open question — whether the Playwright container job benefits proportionally — is already acknowledged in the PR description and is a post-merge observation rather than a blocking concern.

**Files Needing Attention:** No files require special attention. A quick check of the first few `browser` job runs after merge would confirm the container workload scales as expected on the larger runner.
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: right-size 5 runners for faster CI w..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/e1996b5ca42e159ade6dc09bc4c8bb41204a05eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47135625)</sub>

<!-- /greptile_comment -->