### PR TITLE
feat(config): add new DID entry for atproto

### DIFF
--- a/public/.well-known/atproto-did
+++ b/public/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:ss52fcs6v5bkgs7vfgp3txpp


### PR DESCRIPTION
### 🔗 Linked issue

N/A — small domain verification file for AT Protocol identity.

### 🧭 Context

AT Protocol (Bluesky) domain verification expects a DID at `/.well-known/atproto-did` so the site can prove ownership of the handle domain.

### 📚 Description

Adds `public/.well-known/atproto-did` containing `did:plc:ss52fcs6v5bkgs7vfgp3txpp` so the DID document is served at the well-known path after deploy.

No app logic, API, or UI changes. Verification can be confirmed by fetching `/.well-known/atproto-did` on the deployed site and completing AT Protocol handle verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The new file is placed in Nuxt's static public directory and no deployment rules, redirects, or environment-specific assets interfere with serving it at the required well-known path.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(did): add new DID entry for atproto"](https://github.com/wolfstar-project/wolfstar.rocks/commit/abd6bcbe854424693f8bc60e1616d68063db2fc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47253037)</sub>

<!-- /greptile_comment -->