### PR TITLE
feat(config): add opt-in tsgolint type-aware linting support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - Keep functions focused and manageable (generally under 50 lines)
 - Use error handling patterns consistently
 - Ensure you write strictly type-safe code, for example by ensuring you always check when accessing an array value by index
+- Type-aware Oxlint rules (tsgolint-backed, e.g. `@typescript-eslint/no-floating-promises`) run only via the opt-in `pnpm vp run lint:type-aware` task — they are not part of `pnpm lint:fix` or the CI `lint` gate yet
 - Never cast things to `any`
 
 ## Naming Conventions
@@ -97,6 +98,7 @@ pnpm build-storybook             # Build static Storybook output
 pnpm chromatic                   # Publish Storybook to Chromatic for visual review
 pnpm vp run zizmor               # Lint GitHub Actions workflows for security issues (zizmor)
 pnpm vp run zizmor:fix           # Auto-fix zizmor findings
+pnpm vp run lint:type-aware      # Opt-in Oxlint type-aware linting (tsgolint); not part of the default lint/CI gate
 pnpm prisma:push                 # Push schema changes (development)
 pnpm prisma:migrate:dev          # Create and apply migration
 pnpm prisma:migrate:dev:create   # Create a migration without applying it

--- a/knip.ts
+++ b/knip.ts
@@ -65,6 +65,9 @@ const config: KnipConfig = {
 				"eslint-plugin-regexp",
 				"eslint",
 
+				/** Provides the tsgolint binary for oxlint's opt-in type-aware pass (`vp lint --type-aware`), not imported directly */
+				"oxlint-tsgolint",
+
 				/** Used in the app but not imported directly */
 				"@nuxt/icon",
 				"nuxt-security",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
 		"msw": "catalog:msw",
 		"msw-storybook-addon": "catalog:storybook",
 		"nuxt-skill-hub": "^0.1.1",
+		"oxlint-tsgolint": "0.24.0",
 		"prisma": "7.8.0",
 		"prisma-json-types-generator": "5.1.0",
 		"rolldown": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       nuxt-skill-hub:
         specifier: ^0.1.1
         version: 0.1.1(@huggingface/transformers@4.2.0)(ai@6.0.228)(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.132.0)(pg@8.22.0)(rolldown@1.1.4)(sqlite-vec@0.1.9)(unplugin@3.3.0)(unstorage@1.17.5)
+      oxlint-tsgolint:
+        specifier: 0.24.0
+        version: 0.24.0
       prisma:
         specifier: 7.8.0
         version: 7.8.0(@types/react@19.2.17)(magicast@0.5.3)(react-dom@19.2.7)(react@19.2.7)(typescript@6.0.3)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,12 @@ export default defineConfig({
 			"lint": {
 				command: "vp lint && vp fmt --check",
 			},
+			"lint:type-aware": {
+				// tsgolint (typescript-go) doesn't resolve `.vue` module imports, so
+				// `--type-check` floods the run with false TS2307 "cannot find module"
+				// errors on every `.vue` import; `--type-aware` alone stays useful.
+				command: "vp lint --type-aware",
+			},
 			"knip": {
 				command: "knip && knip --production --exclude dependencies",
 			},
@@ -236,6 +242,25 @@ export default defineConfig({
 			"regexp/strict": "error",
 			"regexp/use-ignore-case": "error",
 			"vitest/require-mock-type-parameters": "off",
+			// Type-aware (tsgolint) rules: only active under `vp run lint:type-aware`.
+			// Curated starter set; severity is "warn" while the codebase catches up.
+			"@typescript-eslint/await-thenable": "warn",
+			"@typescript-eslint/no-floating-promises": "warn",
+			"@typescript-eslint/no-misused-promises": "warn",
+			"@typescript-eslint/no-unnecessary-type-assertion": "warn",
+			// The rest of the type-aware rule set that `--type-aware` would otherwise
+			// enable via the correctness/suspicious category defaults above; left off
+			// until we've reviewed them individually.
+			"@typescript-eslint/consistent-return": "off",
+			"@typescript-eslint/no-base-to-string": "off",
+			"@typescript-eslint/no-duplicate-type-constituents": "off",
+			"@typescript-eslint/no-misused-spread": "off",
+			"@typescript-eslint/no-redundant-type-constituents": "off",
+			"@typescript-eslint/no-unnecessary-type-conversion": "off",
+			"@typescript-eslint/no-unnecessary-type-parameters": "off",
+			"@typescript-eslint/no-unsafe-type-assertion": "off",
+			"@typescript-eslint/restrict-template-expressions": "off",
+			"@typescript-eslint/unbound-method": "off",
 		},
 		ignorePatterns: [
 			".output/**",


### PR DESCRIPTION
Oxlint's type-aware linting (tsgolint) went stable per the 2026-07-22
oxc.rs announcement. Add oxlint-tsgolint as an explicit devDependency
and a new `vp run lint:type-aware` task with a curated starter set of
warn-level type-aware rules (no-floating-promises, no-misused-promises,
await-thenable, no-unnecessary-type-assertion). Left as opt-in for now,
separate from the default `lint` task/CI gate, since type-aware checks
require a full TypeScript program build and surface a wave of
pre-existing findings that haven't been triaged yet.

Rule severities must live in the top-level `rules` block rather than in
file-scoped `overrides` — tsgolint's type-aware pass doesn't pick up
override-scoped severities, confirmed via `vp lint --print-config`
vs. actual run output.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RguG19WYcP1yjG8YkkedDA

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into claude/tsgolint..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/90a992dbfb70c534436d3fec9abc4493fcf89423) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47380052)</sub>

<!-- /greptile_comment -->