### PR TITLE
ci: migrate GitHub Actions runners from Blacksmith to Depot

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   code:
     name: 🤖 Autofix code
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: depot-ubuntu-24.04-arm-4
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   chromatic:
     name: 📚 Chromatic
-    runs-on: ubuntu-24.04-arm
+    runs-on: depot-ubuntu-24.04-arm-4
 
     steps:
       - name: ☑️ Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   lint:
     name: 🔠 Lint project
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: depot-ubuntu-24.04-arm-4
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -43,7 +43,7 @@ jobs:
 
   typecheck:
     name: 🔎 Typecheck project
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: depot-ubuntu-24.04-arm-4
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -64,7 +64,7 @@ jobs:
 
   unit:
     name: 🧪 Unit tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: depot-ubuntu-24.04-arm-4
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -103,7 +103,7 @@ jobs:
 
   test:
     name: 🧪 Component tests
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: depot-ubuntu-24.04-arm-8
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -147,7 +147,7 @@ jobs:
 
   browser:
     name: 🖥️ Browser tests
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: depot-ubuntu-24.04-arm-8
     container:
       image: mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48
 
@@ -188,7 +188,7 @@ jobs:
 
   benchmark:
     name: ⚡ Benchmarks
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: depot-ubuntu-24.04-4
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -209,7 +209,7 @@ jobs:
 
   a11y:
     name: ♿ Accessibility audit
-    runs-on: blacksmith-8vcpu-ubuntu-2404 # See https://github.com/GoogleChrome/lighthouse/discussions/16834
+    runs-on: depot-ubuntu-24.04-8 # See https://github.com/GoogleChrome/lighthouse/discussions/16834
     strategy:
       matrix:
         mode: [dark, light]
@@ -241,7 +241,7 @@ jobs:
 
   perf:
     name: ⚡ Performance
-    runs-on: blacksmith-8vcpu-ubuntu-2404 # See https://github.com/GoogleChrome/lighthouse/discussions/16834
+    runs-on: depot-ubuntu-24.04-8 # See https://github.com/GoogleChrome/lighthouse/discussions/16834
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -269,7 +269,7 @@ jobs:
 
   knip:
     name: 🧹 Unused code check
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: depot-ubuntu-24.04-arm-4
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/enforce-release-source.yml
+++ b/.github/workflows/enforce-release-source.yml
@@ -18,7 +18,7 @@ permissions: {}
 jobs:
   enforce-source:
     if: github.repository == 'wolfstar-project/wolfstar.rocks'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: depot-ubuntu-24.04-4
     name: 🚦 Enforce release source
     steps:
       - name: Check PR is from main

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   release-pr:
     name: 🚀 Create or update release PR
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: depot-ubuntu-24.04-4
     if: github.repository == 'wolfstar-project/wolfstar.rocks'
     permissions:
       contents: read

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   tag:
     name: 🏷️ Tag release and create GitHub Release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: depot-ubuntu-24.04-4
     if: github.repository == 'wolfstar-project/wolfstar.rocks'
     permissions:
       contents: write # create release tags and GitHub releases

--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: read # for amannn/action-semantic-pull-request to analyze PRs
       statuses: write # for amannn/action-semantic-pull-request to mark status of analyzed PR
     if: github.repository == 'wolfstar-project/wolfstar.rocks'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: depot-ubuntu-24.04-4
     name: 🏷️ Validate PR title
     steps:
       - name: Validate PR title

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   stale-bugs:
     name: 🧹 Mark stale bug issues
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       issues: write # mark and close stale bug issues
     steps:
@@ -33,7 +33,7 @@ jobs:
 
   stale-prs:
     name: 🧹 Mark stale pull requests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       pull-requests: write # mark and close stale pull requests
     steps:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ permissions: {}
 jobs:
   zizmor:
     name: 🌈 GitHub Actions security analysis
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: depot-ubuntu-24.04-arm-4
     permissions:
       contents: read # checkout repository
 


### PR DESCRIPTION
## Summary
- Replace `blacksmith-*vcpu-ubuntu-2404[-arm]` runner labels with the equivalent `depot-ubuntu-24.04[-arm]-{4,8}` labels across all workflows (ci, autofix, zizmor, stale, release-pr, release-tag, semantic-pull-requests, enforce-release-source, chromatic).

## Test plan
- [ ] Confirm the Depot GitHub App is installed on the `wolfstar-project` org
- [ ] Watch the first CI run on this PR to confirm jobs are picked up by Depot runners

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ci/migrate-blac..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/e9e2e9826989db1d10f3914277eb7e6dc6d7a732) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47420802)</sub>

<!-- /greptile_comment -->