### PR TITLE
chore(docs): update AGENTS.md to reflect recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@
 ## Auth and Feedback
 
 - Authentication runs on `better-auth` + `@onmax/nuxt-better-auth` — `nuxt-auth-utils` was fully removed in #297. Server config lives in `server/auth.config.ts`, built with `defineServerAuth()` from `@onmax/nuxt-better-auth/config`; it registers the Discord social provider (scopes `guilds`, `guilds.members.read`, `email`), rate limiting through `secondaryStorage`, and a `jwe`-strategy session cookie cache
+- `server/auth.config.ts` builds its `secondaryStorage` via `createAuthSecondaryStorage()` from `server/utils/auth-rate-limit-storage.ts`, which adapts a Nitro/unstorage mount to better-auth's `SecondaryStorage` shape and adds an `increment()` with an in-process keyed mutex (mirroring `server/utils/wrappedEventHandler.ts`) so better-auth's fixed-window rate limiter gets a single-step atomic-ish counter instead of its non-atomic get-then-set fallback
+- Mock authentication in Nuxt component tests with `mockAuth()` from `test/nuxt/utils/auth.ts` (wraps `mockNuxtImport("useUserSession", ...)` plus an `$authorization` provide fallback) instead of hand-rolling `useUserSession`/`$authorization` mocks per spec
 - There is no `server/api/auth/discord.get.ts` or `server/utils/oauth-state.ts` anymore. Better-auth's own `/api/auth/sign-in/social` and `/api/auth/callback/discord` routes own the OAuth flow and its CSRF state — do not reintroduce a custom `oauth-state`/`verify-state` endpoint
 - `server/middleware/oauth-callback.ts` + `server/utils/oauth-callback.ts` (`resolveOAuthProviderCallbackRedirect()`) redirect Discord's response at `/oauth/callback` to the better-auth callback path when a `state` query param is present; plain browser navigations to `/oauth/callback` (no `state`) fall through to the Vue callback page at `app/pages/oauth/callback.vue`
 - `server/api/auth/refresh.get.ts` refreshes the Discord access token via `refreshSessionTokens()` in `server/utils/oauth-tokens.ts`, which wraps better-auth's `auth.api.getAccessToken()` / `auth.api.refreshToken()`
@@ -173,7 +175,7 @@ Commit messages must follow Conventional Commits: `<type>(<scope>): <subject>`
 - **OAuth redirect fails:** Ensure `.env` `NUXT_OAUTH_DISCORD_REDIRECT_URL` matches Discord Developer Portal exactly
 - **Hot reload broken:** Check file watcher limits on Linux, restart dev server
 - **Type errors after updates:** Run `pnpm nuxt prepare && pnpm prisma:generate`
-- **Duplicate/incompatible `vue` or `discord-api-types` types after a dependency update:** Check the `overrides` in `pnpm-workspace.yaml` still pin a single version of each — two copies make structurally identical (nominally-branded) types incompatible during typecheck
+- **Duplicate/incompatible `vue`, `discord-api-types`, or `@unhead/vue`/`unhead` types after a dependency update:** Check the `overrides` in `pnpm-workspace.yaml` still pin a single version of each — two copies make structurally identical (nominally-branded) types incompatible during typecheck
 
 **When in doubt:** Copy existing patterns from similar files (e.g., `server/api/guilds/**`, `app/components/discord/**`) before inventing new ones.
 
@@ -273,7 +275,7 @@ It checks:
 Files added to `ALLOW_LIST` in the test are permanently exempt. Current exemptions:
 
 - `app/components/OgImage/Page.takumi.vue` — Satori does not support `var()` references
-- `app/components/discord/*.vue` (message, embed, mention, role, reaction, scrollbar, and the slash-command autocomplete family) — Discord brand fidelity requires Discord brand colors; see `ALLOW_LIST` in the test for the exact, growing file list
+- `app/components/discord/*.vue` (message, embed, mention, role, reaction, scrollbar, the `chat-input-command/` autocomplete family, and the `app-launcher/` family) — Discord brand fidelity requires Discord brand colors; see `ALLOW_LIST` in the test for the exact, growing file list
 
 ### Token Reference
 


### PR DESCRIPTION
### 🔗 Linked issue

None — this is a scheduled weekly maintenance routine that keeps `AGENTS.md` (symlinked from `CLAUDE.md`) in sync with the codebase, not tied to a filed issue.

### 🧭 Context

Reviewed the PRs merged into `main` over the last 7 days and diffed the changed files against the current `AGENTS.md`. Four gaps were found where established patterns weren't documented yet.

### 📚 Description

- **Auth and Feedback**: documented the dedicated `createAuthSecondaryStorage()` adapter in `server/utils/auth-rate-limit-storage.ts` that `server/auth.config.ts` now builds its `secondaryStorage` from, including its keyed-mutex `increment()` (#307). Also documented the restored `mockAuth()` helper in `test/nuxt/utils/auth.ts` for mocking `useUserSession`/`$authorization` in Nuxt component tests (#318).
- **Troubleshooting**: extended the "duplicate/incompatible types after a dependency update" note to cover `@unhead/vue`/`unhead`, which the Nuxt 4.5 upgrade added to `pnpm-workspace.yaml` overrides for the same nominal-branding reason as `vue` and `discord-api-types` (#310).
- **Design Token Discipline allow-list**: updated the description of the Discord-brand-fidelity exemptions to include the `chat-input-command/` family (renamed from the old `slash-command-*.vue` files) and the newly-added `app-launcher/` family (#304).

No other reviewed PRs in the window (#320, #314, #312, #316, #149, #309, #311, #301) introduced patterns, commands, or conventions that AGENTS.md doesn't already cover correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_013QP6o1SrNaeMdn2rjKozcj)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge.

The new guidance is consistent with the repository’s current implementations and enforced configuration, and it introduces no runtime, build, security, or concrete documentation failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(docs): update AGENTS.md to reflect..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/ef4ca49f9628e0cc2d292f774a0b37de3d0e8783) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47434464)</sub>

<!-- /greptile_comment -->