### PR TITLE
chore: configure skew-protection storage for Netlify and local dev

### DIFF
--- a/modules/cache.ts
+++ b/modules/cache.ts
@@ -2,6 +2,7 @@ import { defineNuxtModule, useRuntimeConfig } from "nuxt/kit";
 import { provider } from "std-env";
 // Storage key for fetch cache - must match shared/utils/fetch-cache-config.ts
 const FETCH_CACHE_STORAGE_BASE = "fetch-cache";
+const SKEW_PROTECTION_STORAGE_BASE = "skew-protection";
 
 export default defineNuxtModule({
 	meta: {
@@ -30,6 +31,12 @@ export default defineNuxtModule({
 				...nitroConfig.storage[FETCH_CACHE_STORAGE_BASE],
 				driver: "netlifyBlobs",
 				name: FETCH_CACHE_STORAGE_BASE,
+			};
+
+			nitroConfig.storage[SKEW_PROTECTION_STORAGE_BASE] = {
+				...nitroConfig.storage[SKEW_PROTECTION_STORAGE_BASE],
+				driver: "netlifyBlobs",
+				name: SKEW_PROTECTION_STORAGE_BASE,
 			};
 
 			nitroConfig.storage["wolfstar:ratelimiter"] = {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -339,6 +339,10 @@ export default defineNuxtConfig({
 				base: "./.cache/fetch",
 				driver: "fsLite",
 			},
+			"skew-protection": {
+				base: "./.cache/skew-protection",
+				driver: "fsLite",
+			},
 			"wolfstar:ratelimiter": {
 				base: "./.cache/ratelimiter",
 				driver: "fsLite",


### PR DESCRIPTION
## Summary

- Add `skew-protection` storage mount for Netlify deployments (using `netlifyBlobs` driver)
- Add `skew-protection` storage mount for local development (using `fsLite` driver)
- Storage is used by `nuxt-skew-protection` to track client/server version mismatches

## Testing

- [x] Build succeeds: `pnpm build`
- [x] Type checking passes: `pnpm typecheck`
- [x] Dev server starts: `pnpm dev` (verify no storage initialization errors)
- [x] Storage directories created correctly in `.cache/` on dev startup

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The pull request appears safe to merge with no actionable failures identified.

Netlify replaces the local storage driver through the existing Nitro configuration hook, while non-Netlify local development retains the filesystem-backed mount as intended.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add skew-protection storage configuratio..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/96d95277659bdfa759d6d62367331ba0b0758fc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47908110)</sub>

**Context used:**

- Knowledge Base — [Nuxt Configuration and Build](https://app.greptile.com/wolfstar-project/-/custom-context/knowledge-base/wolfstar-project/wolfstar.rocks/-/docs/nuxt-config-build.md)

<!-- /greptile_comment -->