### PR TITLE
fix(config): enable nuxt-studio in production and drop icon clientBundle list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,9 +27,11 @@ NUXT_BETTER_AUTH_SECRET=
 # Beta/staging (beta.wolfstar.rocks): wolfstar-session-beta
 NUXT_SESSION_COOKIE_NAME=
 
-# Nuxt Studio GitHub OAuth credentials (local development only)
-# Nuxt Studio is registered only when running `nuxt dev`, so it is never exposed
-# in production. Configure the callback URL as http://localhost:3000/__nuxt_studio/auth/github
+# Nuxt Studio GitHub OAuth credentials (required for production publishing;
+# also used when testing the production auth flow locally with studio.dev = false).
+# Configure callback URLs for each environment, e.g.:
+#   http://localhost:3000/__nuxt_studio/auth/github
+#   https://wolfstar.rocks/__nuxt_studio/auth/github
 NUXT_STUDIO_AUTH_GITHUB_CLIENT_ID=
 NUXT_STUDIO_AUTH_GITHUB_CLIENT_SECRET=
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
     name: 🖥️ Browser tests
     runs-on: depot-ubuntu-24.04-arm-8
     container:
-      image: mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48
+      image: mcr.microsoft.com/playwright:v1.62.0-noble@sha256:baed2032d533817f3dbe6425de795788430ba345e819a1201337009ba17c9d07
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/app/components/guild/settings/Moderation.vue
+++ b/app/components/guild/settings/Moderation.vue
@@ -33,6 +33,7 @@ import type { GuildData } from "#server/database";
 import type { FormErrorEvent } from "@nuxt/ui";
 import { ModerationSettingsSchema, type ModerationSettingsSchemaType } from "#shared/schemas";
 import { setGuildDataChange } from "#shared/utils/guild-settings-map";
+import { ConfigurableModerationKeys } from "#shared/utils/settingsDataEntries";
 
 const { guildSettings } = useGuildSettings();
 const toast = useToast();

--- a/config/pwa.ts
+++ b/config/pwa.ts
@@ -18,9 +18,9 @@ export const pwa: ModuleOptions = {
 		// Blog post images are runtime content, not app-shell assets. Keep them out
 		// of the precache manifest so large images (e.g. OG images) don't exceed
 		// workbox's file-size limit and fail the build.
-		// Nuxt Studio editor/auth chunks are multi-MB and only needed on /_studio —
-		// exclude them so production builds with nuxt-studio don't blow the precache.
-		globIgnores: ["**/assets/blog/**", "**/*studio*", "**/*monaco*", "**/*tiptap*"],
+		// Nuxt Studio ships multi-MB editor apps under `_studio-app/` — exclude the
+		// whole tree so production builds with nuxt-studio don't blow the precache.
+		globIgnores: ["**/assets/blog/**", "**/_studio-app/**"],
 	},
 	injectRegister: "auto",
 	manifest: {

--- a/config/pwa.ts
+++ b/config/pwa.ts
@@ -18,7 +18,9 @@ export const pwa: ModuleOptions = {
 		// Blog post images are runtime content, not app-shell assets. Keep them out
 		// of the precache manifest so large images (e.g. OG images) don't exceed
 		// workbox's file-size limit and fail the build.
-		globIgnores: ["**/assets/blog/**"],
+		// Nuxt Studio editor/auth chunks are multi-MB and only needed on /_studio —
+		// exclude them so production builds with nuxt-studio don't blow the precache.
+		globIgnores: ["**/assets/blog/**", "**/*studio*", "**/*monaco*", "**/*tiptap*"],
 	},
 	injectRegister: "auto",
 	manifest: {

--- a/knip.ts
+++ b/knip.ts
@@ -72,9 +72,6 @@ const config: KnipConfig = {
 				"@nuxt/icon",
 				"nuxt-security",
 
-				/** Registered as a Nuxt module via a conditional spread in nuxt.config.ts (skipped in test/Storybook), so knip can't resolve it statically */
-				"nuxt-studio",
-
 				/** Used in the app in guild/logs components */
 				"@tanstack/table-core",
 

--- a/knip.ts
+++ b/knip.ts
@@ -72,7 +72,7 @@ const config: KnipConfig = {
 				"@nuxt/icon",
 				"nuxt-security",
 
-				/** Registered as a Nuxt module only in dev via a conditional spread in nuxt.config.ts, so knip can't resolve it statically */
+				/** Registered as a Nuxt module via a conditional spread in nuxt.config.ts (skipped in test/Storybook), so knip can't resolve it statically */
 				"nuxt-studio",
 
 				/** Used in the app in guild/logs components */

--- a/knip.ts
+++ b/knip.ts
@@ -6,7 +6,6 @@ const config: KnipConfig = {
 		".": {
 			entry: [
 				"service-worker/sw.ts",
-				"pwa-assets.config.ts",
 				"taze.config.ts",
 				"modules/**/*.ts",
 				".lighthouserc.cjs",
@@ -25,7 +24,8 @@ const config: KnipConfig = {
 				"test/__stubs__/prisma-generated-client.ts",
 			],
 			project: [
-				"**/*.{ts,vue,cjs,mjs}",
+				/** css/mdx/prisma are handled by registered compilers, so include them here */
+				"**/*.{ts,vue,cjs,mjs,css,mdx,prisma}",
 				"!test/fixtures/**",
 				"!test/test-utils/**",
 				"!test/e2e/helpers/**",
@@ -54,16 +54,9 @@ const config: KnipConfig = {
 				"@discordjs/rest",
 				"@sapphire/async-queue",
 				"@codspeed/core",
-				"nuxt-og-image",
-				"@takumi-rs/core",
-				"@takumi-rs/wasm",
+				"nuxt-site-config",
 				"workbox-*",
 				"rolldown",
-
-				/** Oxlint plugins don't get picked up yet */
-				"@e18e/eslint-plugin",
-				"eslint-plugin-regexp",
-				"eslint",
 
 				/** Provides the tsgolint binary for oxlint's opt-in type-aware pass (`vp lint --type-aware`), not imported directly */
 				"oxlint-tsgolint",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -482,7 +482,14 @@ export default defineNuxtConfig({
 	icon: {
 		clientBundle: {
 			includeCustomCollections: true,
-			scan: true,
+			// App Launcher fixtures pass icon names dynamically from .ts data
+			// (app/utils/constants.ts), which the default scan globs
+			// (vue/jsx/tsx/md/mdc/mdx/yml/yaml) miss — include .ts so those
+			// icons stay in the client bundle instead of falling back to
+			// runtime fetches.
+			scan: {
+				globInclude: ["**/*.{vue,jsx,tsx,md,mdc,mdx,yml,yaml,ts}"],
+			},
 		},
 		customCollections: [
 			{

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,7 @@
 import netlifyNuxt from "@netlify/nuxt";
 import { auditRedactPreset } from "evlog";
 import { createResolver } from "nuxt/kit";
-import { isCI, isDevelopment, isTest, provider } from "std-env";
+import { isCI, isTest, provider } from "std-env";
 import { pwa } from "./config/pwa";
 import { generateRuntimeConfig } from "./server/utils/runtimeConfig";
 
@@ -16,11 +16,11 @@ export default defineNuxtConfig({
 	modules: [
 		"@nuxt/ui",
 		"@nuxt/content",
-		// Nuxt Studio is a local content-editing tool. It ships multi-MB editor
-		// bundles that overflow the PWA precache (breaking the build) and registers
-		// Vite plugins that break the rolldown-based Vitest environment, so only
-		// load it during local development.
-		...(isDevelopment ? ["nuxt-studio"] : []),
+		// Nuxt Studio works in development and production (Git publish needs prod).
+		// Skip it in Vitest/Storybook: its Vite plugins break the rolldown-based
+		// test environment. Studio editor chunks are also excluded from the PWA
+		// precache in config/pwa.ts so multi-MB bundles don't fail the build.
+		...(isTest || isStorybook ? [] : ["nuxt-studio"]),
 		"@nuxt/image",
 		"@nuxt/hints",
 		"@nuxt/fonts",
@@ -289,6 +289,10 @@ export default defineNuxtConfig({
 		// Changelog pulls live GitHub releases from ungh.cc, so it revalidates via
 		// ISR (1 hour) rather than prerendering against the external API at build time.
 		"/changelog": { appLayout: "default", robots: true, ...getISRConfig(60 * 60) },
+		// Nuxt Studio admin UI + auth callbacks — SSR-only, never index or prerender.
+		"/_studio": { prerender: false, robots: false },
+		"/_studio/**": { prerender: false, robots: false },
+		"/__nuxt_studio/**": { prerender: false, robots: false },
 	},
 
 	sourcemap: {
@@ -322,7 +326,7 @@ export default defineNuxtConfig({
 			crawlLinks: true,
 			// Keep redirect-only and per-user routes out of the prerender crawl;
 			// their auth-redirect stubs do not produce complete HTML documents.
-			ignore: ["/login", "/oauth/login", "/profile"],
+			ignore: ["/login", "/oauth/login", "/profile", "/_studio", "/__nuxt_studio"],
 		},
 		publicAssets: [
 			{
@@ -468,61 +472,6 @@ export default defineNuxtConfig({
 
 	icon: {
 		clientBundle: {
-			// App Launcher fixtures pass icon names dynamically, so scanning cannot detect them.
-			icons: [
-				"ph:flame-fill",
-				"ph:circles-three-fill",
-				"ph:circles-four-fill",
-				"ph:squares-four-fill",
-				"ph:number-circle-eight-fill",
-				"ph:diamond-fill",
-				"ph:grid-nine",
-				"ph:flower-lotus-fill",
-				"ph:plant-fill",
-				"ph:youtube-logo-fill",
-				"ph:flask-fill",
-				"ph:spade-fill",
-				"ph:golf-fill",
-				"ph:waveform-fill",
-				"ph:shield-star-fill",
-				"ph:hand-pointing-fill",
-				"ph:soccer-ball-fill",
-				"ph:rocket-launch-fill",
-				"ph:image-square-fill",
-				"ph:planet-fill",
-				"ph:discord-logo-fill",
-				"ph:cat-fill",
-				"ph:music-notes-fill",
-				"ph:vinyl-record-fill",
-				"ph:terminal-window-fill",
-				"ph:grid-four-fill",
-				"ph:headphones-fill",
-				"ph:microphone-stage-fill",
-				"ph:pencil-simple-fill",
-				"ph:checkerboard-fill",
-				"ph:map-trifold-fill",
-				"ph:phone-fill",
-				"ph:smiley-sticker-fill",
-				"ph:chat-teardrop-dots-fill",
-				"ph:palette-fill",
-				"ph:lightning-fill",
-				"ph:crosshair-fill",
-				"ph:sword-fill",
-				"ph:number-square-one-fill",
-				"ph:hexagon-fill",
-				"ph:number-eight-fill",
-				"ph:cards-three-fill",
-				"ph:dice-five-fill",
-				"ph:horse-fill",
-				"ph:shield-chevron-fill",
-				"ph:detective-fill",
-				"ph:person-simple-run-fill",
-				"ph:crosshair-simple-fill",
-				"ph:car-profile-fill",
-				"ph:target-fill",
-				"ph:smiley-melting-fill",
-				"ph:fish-simple-fill",
-			],
 			includeCustomCollections: true,
 			scan: true,
 		},

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -60,6 +60,15 @@ export default defineNuxtConfig({
 		},
 	},
 
+	studio: {
+		repository: {
+			provider: "github",
+			owner: "wolfstar-project",
+			repo: "wolfstar.rocks",
+			branch: "main",
+		},
+	},
+
 	$development: {
 		site: {
 			name: "WolfStar (Dev)",

--- a/test/nuxt/utils/auth.ts
+++ b/test/nuxt/utils/auth.ts
@@ -42,10 +42,14 @@ export function mockAuth(user: Partial<AuthUser> | null = null) {
 	}));
 
 	beforeEach(() => {
-		// authorization-resolver does not run here; mockNuxtImport also cannot
-		// replace useUserSession in Vitest browser + viteEnvironmentApi:false.
+		// mockNuxtImport cannot replace useUserSession in Vitest browser +
+		// viteEnvironmentApi:false, so when the authorization-resolver plugin ran
+		// its resolveClientUser reads the real (empty) session — override the
+		// method on the provided object; otherwise provide the mock ourselves.
 		const app = useNuxtApp();
-		if (!app.$authorization) {
+		if (app.$authorization) {
+			app.$authorization.resolveClientUser = () => resolvedUser;
+		} else {
 			app.provide("authorization", {
 				resolveClientUser: () => resolvedUser,
 			});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🔗 Linked issue

N/A — config cleanup requested directly.

### 🧭 Context

`icon.clientBundle.icons` was a redundant App Launcher allowlist, and `nuxt-studio` was gated to `isDevelopment` even though Studio’s publish flow is meant for production.

### 📚 Description

- Removed the hardcoded `icon.clientBundle.icons` list; client-bundle scanning already covers icons.
- Register `nuxt-studio` in production and local dev (still skipped in Vitest/Storybook because its Vite plugins break that environment).
- Added explicit `studio.repository` for `wolfstar-project/wolfstar.rocks` so production builds work outside Netlify auto-detection.
- Exclude `_studio-app/**` from the PWA precache so multi-MB Studio editor bundles do not fail Workbox size checks.
- Keep `/_studio` and `/__nuxt_studio` out of prerender/indexing, and update `.env.example` for production OAuth callbacks.
- Dropped the obsolete `nuxt-studio` knip `ignoreDependencies` entry.

Verified locally: `pnpm build` (with `NUXT_PUBLIC_SITE_URL`), `pnpm lint:fix`, `pnpm typecheck`, and `pnpm test:unit` pass.

Note: Component/browser/knip failures currently match `main` HEAD (pre-existing Moderation auto-import / Playwright path / `nuxt-site-config` knip issues from #325).

### Test plan

- [x] `pnpm build` succeeds with Studio enabled and PWA injectManifest
- [x] `pnpm lint:fix` / `pnpm typecheck` / `pnpm test:unit` pass
- [ ] Confirm `/_studio` is available on a production deploy
- [ ] Confirm App Launcher icons still resolve via Iconify (no allowlist)
- [ ] Ensure `NUXT_STUDIO_AUTH_GITHUB_*` OAuth callbacks include the production URL
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1723ec6-e9b2-4566-a7dc-150f3d22a4e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1723ec6-e9b2-4566-a7dc-150f3d22a4e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The configured scanner reads TypeScript files and extracts the literal icon names used by the dynamic launcher bindings, so the launcher icons remain covered without the explicit list.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The build output reported using repository github:wolfstar-project/wolfstar.rocks#main and finished with Build complete! and exit code 0.
- The PWA generation produced mode injectManifest, precached 389 entries (11754.84 KiB), sw.js, and Build complete with exit code 0.
- Artifact inspection found approximately 34 MB of generated Studio assets and confirmed sw.js references \_studio-app: 0.
- The before capture documented the environment's default-heap OOM condition.
- The after capture demonstrated that the production path completes when sufficient heap is provided.

<a href="https://app.greptile.com/trex/runs/16271707/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): bump Playwright container image..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/d18836b538b114ab2d9ad727046a231497e266b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48052874)</sub>

<!-- /greptile_comment -->