### PR TITLE
feat(config): enable builder-reuse file watcher (experimental)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -326,6 +326,8 @@ export default defineNuxtConfig({
 		typescriptPlugin: true,
 		viteEnvironmentApi: !isStorybook,
 		typedPages: true,
+		// Reuses Vite's own file watcher instead of starting a second one.
+		watcher: "builder",
 	},
 
 	compatibilityDate: "2025-09-20",


### PR DESCRIPTION
### 🔗 Linked issue

N/A — small experimental config change

### 🧭 Context

Nuxt's `experimental.watcher` option controls which file-watching service Nuxt uses in dev. The `"builder"` value reuses the active builder's own watcher (Vite's `server.watcher`) instead of starting a second, separate watcher process.

### 📚 Description

Set `experimental.watcher: "builder"` in `nuxt.config.ts` so dev file watching reuses Vite's own watcher instead of spinning up a second `chokidar`/`parcel` instance alongside it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the nuxt-watcher-builder end-to-end harness, which creates and then deletes an isolated fixture.
- The harness symlinked dependencies from the installed project to the isolated fixture to keep the test environment isolated.
- It captured two runs and saved the outputs to the baseline and after logs for validation.
- The PR configuration was recorded with the exact experimental watcher setting builder in the after log, alongside the before/after live HTTP markers and Vite server HMR, and all steps exited cleanly.

<a href="https://app.greptile.com/trex/runs/16665775/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(config): enable builder-reuse file ..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/4df74e9065e7877ebb802995e0c4c86cd4d391ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48850934)</sub>

<!-- /greptile_comment -->