### PR TITLE
chore(i18n): point Tolgee CLI at project 33768 and ensure languages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,8 +90,8 @@ NUXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=
 # ===================================
 # Tolgee (optional — CLI push/pull)
 # ===================================
-# Project API Key or PAT for project 33602 (Wolfstar Site).
-# Same key used by the Tolgee MCP server. Never commit the real value.
+# Project API Key or PAT for project 33768 (Wolfstar Website).
+# A PAT from `tolgee login` also works. Never commit the real value.
 TOLGEE_API_KEY=
 
 # ===================================

--- a/.tolgeerc.cjs
+++ b/.tolgeerc.cjs
@@ -1,16 +1,20 @@
 /**
- * Tolgee CLI config for WolfStar.rocks (project "Wolfstar Site", id 33602).
+ * Tolgee CLI config for WolfStar.rocks (project "Wolfstar Website", id 33768).
  *
  * Local layout: i18n/locales/{nuxtLocale}/{namespace}.json
  * Tolgee tags are shorter (cs-CZ → cs, zh-CN → zh-Hans, …). Base English
  * lives in `en/` (same content as en-US); base Spanish in `es/` (≈ es-ES).
+ *
+ * Push maps each file via `push.files[*].language` to those short tags. The
+ * platform must already have matching languages — run
+ * `node scripts/tolgee-ensure-languages.mjs` after creating/cloning a project.
  *
  * Free plan key limit is 500; this repo has ~552 string keys across namespaces.
  * Prefer pushing only languages with real translations until the plan is upgraded:
  *   pnpm tolgee:push -- --languages en es it
  *
  * Set TOLGEE_API_KEY (Project API Key or PAT) in the environment — never commit it.
- * The same key is configured on the Tolgee MCP server in Cursor.
+ * `tolgee login` PAT also works. MCP may still point at the older Wolfstar (33602) PAK.
  */
 const NAMESPACES = ["common", "auth", "dashboard", "guilds", "profile", "components"];
 

--- a/.tolgeerc.cjs
+++ b/.tolgeerc.cjs
@@ -56,7 +56,7 @@ const pushFiles = Object.entries(LOCALE_MAP).flatMap(([localDir, language]) =>
 
 module.exports = {
 	$schema: "https://docs.tolgee.io/cli-schema.json",
-	projectId: 33602,
+	projectId: 33768,
 	format: "JSON_TOLGEE",
 	parser: "vue",
 	// App deep-merges feature files; keys are used without vue-i18n namespaces.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"i18n:report:fix": "node --experimental-transform-types scripts/remove-unused-translations.ts",
 		"tolgee:push": "tolgee push",
 		"tolgee:pull": "tolgee pull && node --experimental-transform-types scripts/tolgee-pull-remap.ts",
+		"tolgee:ensure-languages": "node scripts/tolgee-ensure-languages.mjs",
 		"tolgee:extract": "tolgee extract print",
 		"build:test": "TEST=1 vp run build",
 		"dev": "nuxt dev",

--- a/scripts/tolgee-ensure-languages.mjs
+++ b/scripts/tolgee-ensure-languages.mjs
@@ -1,0 +1,139 @@
+/**
+ * Ensure Tolgee project languages exist for every tag in `.tolgeerc.cjs` LOCALE_MAP.
+ *
+ * Uses the same CLI login store as `tolgee` (`~/.config/tolgee/authentication.json`)
+ * or `TOLGEE_API_KEY` when set. Creates only missing tags (idempotent).
+ *
+ * Usage: node scripts/tolgee-ensure-languages.mjs
+ */
+/* oxlint-disable no-console */
+/* oxlint-disable no-underscore-dangle -- Tolgee HAL responses use `_embedded` */
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const config = require("../.tolgeerc.cjs");
+
+const API = (process.env.TOLGEE_API_URL || "https://app.tolgee.io").replace(/\/$/, "");
+const PROJECT_ID = Number(config.projectId);
+
+/** Display metadata for tags we push (matches Wolfstar / Tolgee defaults). */
+const LANGUAGE_META = {
+	"en-GB": {
+		name: "English (United Kingdom)",
+		originalName: "English (United Kingdom)",
+		flagEmoji: "🇬🇧",
+	},
+	"es": { name: "Spanish", originalName: "español", flagEmoji: "🇪🇸" },
+	"es-419": {
+		name: "Spanish (Latin America)",
+		originalName: "español (Latinoamérica)",
+		flagEmoji: "🇲🇽",
+	},
+	"cs": { name: "Czech", originalName: "čeština", flagEmoji: "🇨🇿" },
+	"da": { name: "Danish", originalName: "dansk", flagEmoji: "🇩🇰" },
+	"de": { name: "German", originalName: "Deutsch", flagEmoji: "🇩🇪" },
+	"el": { name: "Greek", originalName: "Ελληνικά", flagEmoji: "🇬🇷" },
+	"fi": { name: "Finnish", originalName: "suomi", flagEmoji: "🇫🇮" },
+	"fr": { name: "French", originalName: "français", flagEmoji: "🇫🇷" },
+	"hi": { name: "Hindi", originalName: "हिन्दी", flagEmoji: "🇮🇳" },
+	"hr": { name: "Croatian", originalName: "hrvatski", flagEmoji: "🇭🇷" },
+	"hu": { name: "Hungarian", originalName: "magyar", flagEmoji: "🇭🇺" },
+	"id": { name: "Indonesian", originalName: "Indonesia", flagEmoji: "🇮🇩" },
+	"it": { name: "Italian", originalName: "italiano", flagEmoji: "🇮🇹" },
+	"ko": { name: "Korean", originalName: "한국어", flagEmoji: "🇰🇷" },
+	"lt": { name: "Lithuanian", originalName: "lietuvių", flagEmoji: "🇱🇹" },
+	"nl": { name: "Dutch", originalName: "Nederlands", flagEmoji: "🇳🇱" },
+	"pt": { name: "Portuguese", originalName: "português", flagEmoji: "🇵🇹" },
+	"ro": { name: "Romanian", originalName: "română", flagEmoji: "🇷🇴" },
+	"ru": { name: "Russian", originalName: "русский", flagEmoji: "🇷🇺" },
+	"tr": { name: "Turkish", originalName: "Türkçe", flagEmoji: "🇹🇷" },
+	"uk": { name: "Ukrainian", originalName: "українська", flagEmoji: "🇺🇦" },
+};
+
+function resolveApiKey() {
+	if (process.env.TOLGEE_API_KEY) return process.env.TOLGEE_API_KEY;
+	const authPath = join(homedir(), ".config/tolgee/authentication.json");
+	const auth = JSON.parse(readFileSync(authPath, "utf8"));
+	const host = new URL(API).host;
+	const entry = auth[host] || auth["app.tolgee.io"];
+	const key = entry?.user?.token || entry?.projects?.[String(PROJECT_ID)]?.token;
+	if (!key) {
+		throw new Error(
+			`No Tolgee API key found. Set TOLGEE_API_KEY or run \`pnpm exec tolgee login\`.`,
+		);
+	}
+	return key;
+}
+
+async function api(path, { method = "GET", body, apiKey } = {}) {
+	const res = await fetch(`${API}${path}`, {
+		method,
+		headers: {
+			"X-API-Key": apiKey,
+			...(body ? { "Content-Type": "application/json" } : {}),
+		},
+		...(body ? { body: JSON.stringify(body) } : {}),
+	});
+	const text = await res.text();
+	let json;
+	try {
+		json = text ? JSON.parse(text) : null;
+	} catch {
+		json = { raw: text };
+	}
+	if (!res.ok) {
+		const err = new Error(`${method} ${path} → ${res.status}: ${text.slice(0, 300)}`);
+		err.status = res.status;
+		err.body = json;
+		throw err;
+	}
+	return json;
+}
+
+const neededTags = [...new Set(config.push.files.map((f) => f.language))].toSorted();
+const apiKey = resolveApiKey();
+
+const project = await api(`/v2/projects/${PROJECT_ID}`, { apiKey });
+console.log(`Project ${PROJECT_ID} (${project.name})`);
+
+const listed = await api(`/v2/projects/${PROJECT_ID}/languages?size=100`, { apiKey });
+const existing = new Set((listed._embedded?.languages || []).map((l) => l.tag));
+console.log(`Existing: ${[...existing].toSorted().join(", ") || "(none)"}`);
+
+let created = 0;
+let skipped = 0;
+for (const tag of neededTags) {
+	if (existing.has(tag)) {
+		skipped++;
+		continue;
+	}
+	const meta = LANGUAGE_META[tag] || {
+		name: tag,
+		originalName: tag,
+		flagEmoji: "🏳️",
+	};
+	if (tag === "en") {
+		console.warn(`Base language "en" missing — create it in the Tolgee UI first.`);
+		continue;
+	}
+	await api(`/v2/projects/${PROJECT_ID}/languages`, {
+		method: "POST",
+		apiKey,
+		body: { tag, ...meta },
+	});
+	created++;
+	console.log(`Created ${tag}`);
+}
+
+const after = await api(`/v2/projects/${PROJECT_ID}/languages?size=100`, { apiKey });
+const tags = (after._embedded?.languages || []).map((l) => l.tag).toSorted();
+const missing = neededTags.filter((t) => !tags.includes(t));
+console.log(`Done. created=${created} alreadyPresent=${skipped}`);
+console.log(`Languages: ${tags.join(", ")}`);
+if (missing.length) {
+	console.error(`Still missing: ${missing.join(", ")}`);
+	process.exit(1);
+}


### PR DESCRIPTION
### 🔗 Linked issue

N/A — points the Tolgee CLI at the new project and adds a helper for language setup.

### 🧭 Context

Tolgee work moved from project **33602** (“Wolfstar Site”) to **33768** (“Wolfstar Website”). Push maps local locale dirs to short language tags that must already exist on the platform; a fresh/cloned project often lacks them.

### 📚 Description

- Update `.tolgeerc.cjs` `projectId` and docs for project **33768**
- Refresh `.env.example` comments for the new project / PAT usage
- Add `scripts/tolgee-ensure-languages.mjs` (idempotent) to create missing Tolgee languages from `LOCALE_MAP`
- Expose it as `pnpm tolgee:ensure-languages`

**Test plan**
- [x] Confirm `.tolgeerc.cjs` has `projectId: 33768`
- [ ] With `TOLGEE_API_KEY` or `tolgee login`, run `pnpm tolgee:ensure-languages` and verify missing tags are created (or already present)
- [ ] Smoke `pnpm tolgee:push -- --languages en` against the new project (optional; needs API access)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Do not merge until the credential lookup uses the selected host safely.

The new provisioning command has two reproduced credential-handling failures: it rejects valid CLI credentials for non-default-port instances and can disclose a hosted token to another configured API host.

**Files Needing Attention:** scripts/tolgee-ensure-languages.mjs
</details>

<details open><summary><h3>Security Review</h3></summary>

When `TOLGEE_API_URL` points to a host without a matching saved credential, the helper falls back to the `app.tolgee.io` token and sends it in an `X-API-Key` header to the configured host. A self-hosted or otherwise redirected endpoint can therefore receive a hosted-service credential before reporting an authentication error.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a finding-comment-proof for a P1 credential-resolution issue, with harness and test artifacts showing hostname-based and port-qualified credential behavior.
- T-Rex produced a second finding-comment-proof for a Tolgee credential routing isolation test, with artifacts covering the focused harness source and fallback tests.
- T-Rex produced a third finding-comment-proof for another P1 finding, supported by its harness artifact.
- T-Rex performed contract validation showing the before state (hostname-only credential with no mock requests) and the after state (port-qualified credential provisioning against the mock API), with harness outputs captured.
- T-Rex documented a general contract validation noting the focused Tolgee fallback harness source and the corresponding before/after run outputs and headers.

<a href="https://app.greptile.com/trex/runs/16916524/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Ftolgee-ensure-languages.mjs%3A60%0A**Non-default-port%20credentials%20cannot%20be%20resolved**%0A%0A%60new%20URL%28API%29.host%60%20includes%20a%20non-default%20port%2C%20but%20the%20Tolgee%20CLI%20stores%20authentication%20entries%20using%20the%20URL%20hostname%20without%20that%20port.%20A%20CLI%20login%20for%20a%20self-hosted%20URL%20such%20as%20%60http%3A%2F%2Ftolgee.internal%3A8080%60%20is%20consequently%20not%20found%20by%20this%20helper%2C%20which%20exits%20before%20making%20an%20API%20request.%20Use%20%60.hostname%60%20for%20this%20lookup%20so%20the%20helper%20uses%20the%20same%20credential%20key%20as%20the%20CLI.%0A%0A%23%23%23%20Issue%202%0Ascripts%2Ftolgee-ensure-languages.mjs%3A61%0A**Hosted%20credential%20is%20sent%20to%20another%20API%20host**%0A%0AWhen%20an%20explicitly%20selected%20self-hosted%20API%20has%20no%20matching%20authentication%20entry%2C%20this%20fallback%20silently%20uses%20%60auth%5B%22app.tolgee.io%22%5D%60.%20The%20helper%20then%20sends%20that%20hosted%20Tolgee%20token%20in%20%60X-API-Key%60%20requests%20to%20the%20configured%20host%20rather%20than%20reporting%20missing%20credentials.%20Restrict%20lookup%20to%20the%20selected%20host%2C%20or%20only%20permit%20the%20hosted%20fallback%20when%20the%20selected%20API%20is%20%60app.tolgee.io%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=wolfstar-project%2Fwolfstar.rocks&pr=342&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Ascripts%2Ftolgee-ensure-languages.mjs%3A60%0A**Non-default-port%20credentials%20cannot%20be%20resolved**%0A%0A%60new%20URL%28API%29.host%60%20includes%20a%20non-default%20port%2C%20but%20the%20Tolgee%20CLI%20stores%20authentication%20entries%20using%20the%20URL%20hostname%20without%20that%20port.%20A%20CLI%20login%20for%20a%20self-hosted%20URL%20such%20as%20%60http%3A%2F%2Ftolgee.internal%3A8080%60%20is%20consequently%20not%20found%20by%20this%20helper%2C%20which%20exits%20before%20making%20an%20API%20request.%20Use%20%60.hostname%60%20for%20this%20lookup%20so%20the%20helper%20uses%20the%20same%20credential%20key%20as%20the%20CLI.%0A%0A%23%23%23%20Issue%202%0Ascripts%2Ftolgee-ensure-languages.mjs%3A61%0A**Hosted%20credential%20is%20sent%20to%20another%20API%20host**%0A%0AWhen%20an%20explicitly%20selected%20self-hosted%20API%20has%20no%20matching%20authentication%20entry%2C%20this%20fallback%20silently%20uses%20%60auth%5B%22app.tolgee.io%22%5D%60.%20The%20helper%20then%20sends%20that%20hosted%20Tolgee%20token%20in%20%60X-API-Key%60%20requests%20to%20the%20configured%20host%20rather%20than%20reporting%20missing%20credentials.%20Restrict%20lookup%20to%20the%20selected%20host%2C%20or%20only%20permit%20the%20hosted%20fallback%20when%20the%20selected%20API%20is%20%60app.tolgee.io%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=342&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22wolfstar-project%2Fwolfstar.rocks%22%20on%20the%20existing%20branch%20%22chore%2Ftolgee-project-id%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Ftolgee-project-id%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Ftolgee-ensure-languages.mjs%3A60%0A**Non-default-port%20credentials%20cannot%20be%20resolved**%0A%0A%60new%20URL%28API%29.host%60%20includes%20a%20non-default%20port%2C%20but%20the%20Tolgee%20CLI%20stores%20authentication%20entries%20using%20the%20URL%20hostname%20without%20that%20port.%20A%20CLI%20login%20for%20a%20self-hosted%20URL%20such%20as%20%60http%3A%2F%2Ftolgee.internal%3A8080%60%20is%20consequently%20not%20found%20by%20this%20helper%2C%20which%20exits%20before%20making%20an%20API%20request.%20Use%20%60.hostname%60%20for%20this%20lookup%20so%20the%20helper%20uses%20the%20same%20credential%20key%20as%20the%20CLI.%0A%0A%23%23%23%20Issue%202%0Ascripts%2Ftolgee-ensure-languages.mjs%3A61%0A**Hosted%20credential%20is%20sent%20to%20another%20API%20host**%0A%0AWhen%20an%20explicitly%20selected%20self-hosted%20API%20has%20no%20matching%20authentication%20entry%2C%20this%20fallback%20silently%20uses%20%60auth%5B%22app.tolgee.io%22%5D%60.%20The%20helper%20then%20sends%20that%20hosted%20Tolgee%20token%20in%20%60X-API-Key%60%20requests%20to%20the%20configured%20host%20rather%20than%20reporting%20missing%20credentials.%20Restrict%20lookup%20to%20the%20selected%20host%2C%20or%20only%20permit%20the%20hosted%20fallback%20when%20the%20selected%20API%20is%20%60app.tolgee.io%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.&repo=wolfstar-project%2Fwolfstar.rocks&uid=108079&ts=1785620289&sig=5ca1a5786f933c3b37ebbecec5628e895345dbf67657119f8555cf857281b5d0&pr=342&platform=github&fid=8b815526-e8fd-49b1-a810-f626eab6d60d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/tolgee-ensure-languages.mjs:60
**Non-default-port credentials cannot be resolved**

`new URL(API).host` includes a non-default port, but the Tolgee CLI stores authentication entries using the URL hostname without that port. A CLI login for a self-hosted URL such as `http://tolgee.internal:8080` is consequently not found by this helper, which exits before making an API request. Use `.hostname` for this lookup so the helper uses the same credential key as the CLI.

### Issue 2
scripts/tolgee-ensure-languages.mjs:61
**Hosted credential is sent to another API host**

When an explicitly selected self-hosted API has no matching authentication entry, this fallback silently uses `auth["app.tolgee.io"]`. The helper then sends that hosted Tolgee token in `X-API-Key` requests to the configured host rather than reporting missing credentials. Restrict lookup to the selected host, or only permit the hosted fallback when the selected API is `app.tolgee.io`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update Tolgee project details and..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/e84c908af9c4e7d3eee567ceabed0e7f49d41667) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49382070)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->