### PR TITLE
ci: migrate from Blacksmith to GitHub-hosted runners

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   code:
     name: 🤖 Autofix code
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   lint:
     name: 🔠 Lint project
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -43,7 +43,7 @@ jobs:
 
   typecheck:
     name: 🔎 Typecheck project
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -64,7 +64,7 @@ jobs:
 
   unit:
     name: 🧪 Unit tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     env:
       # Match package.json test scripts; CI calls `vp test` directly.
       TEST: "1"
@@ -106,7 +106,7 @@ jobs:
 
   test:
     name: 🧪 Component tests
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     env:
       # Match package.json test scripts; CI calls `vp test` directly.
       TEST: "1"
@@ -153,7 +153,7 @@ jobs:
 
   browser:
     name: 🖥️ Browser tests
-    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     container:
       image: mcr.microsoft.com/playwright:v1.62.0-noble@sha256:baed2032d533817f3dbe6425de795788430ba345e819a1201337009ba17c9d07
 
@@ -194,7 +194,7 @@ jobs:
 
   benchmark:
     name: ⚡ Benchmarks
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -215,7 +215,7 @@ jobs:
 
   a11y:
     name: ♿ Accessibility audit
-    runs-on: blacksmith-8vcpu-ubuntu-2404 # See https://github.com/GoogleChrome/lighthouse/discussions/16834
+    runs-on: ubuntu-latest # See https://github.com/GoogleChrome/lighthouse/discussions/16834
     strategy:
       matrix:
         mode: [dark, light]
@@ -247,7 +247,7 @@ jobs:
 
   perf:
     name: ⚡ Performance
-    runs-on: blacksmith-8vcpu-ubuntu-2404 # See https://github.com/GoogleChrome/lighthouse/discussions/16834
+    runs-on: ubuntu-latest # See https://github.com/GoogleChrome/lighthouse/discussions/16834
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -275,7 +275,7 @@ jobs:
 
   knip:
     name: 🧹 Unused code check
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -293,7 +293,7 @@ jobs:
 
   i18n:
     name: 🌐 i18n validation
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/enforce-release-source.yml
+++ b/.github/workflows/enforce-release-source.yml
@@ -18,7 +18,7 @@ permissions: {}
 jobs:
   enforce-source:
     if: github.repository == 'wolfstar-project/wolfstar.rocks'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     name: 🚦 Enforce release source
     steps:
       - name: Check PR is from main

--- a/.github/workflows/lunaria.yml
+++ b/.github/workflows/lunaria.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   lunaria-overview:
     name: 🌝 Generate Lunaria Overview
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       pull-requests: write # post Lunaria overview comments on pull requests

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   release-pr:
     name: 🚀 Create or update release PR
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.repository == 'wolfstar-project/wolfstar.rocks'
     permissions:
       contents: read

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   tag:
     name: 🏷️ Tag release and create GitHub Release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.repository == 'wolfstar-project/wolfstar.rocks'
     permissions:
       contents: write # create release tags and GitHub releases

--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: read # for amannn/action-semantic-pull-request to analyze PRs
       statuses: write # for amannn/action-semantic-pull-request to mark status of analyzed PR
     if: github.repository == 'wolfstar-project/wolfstar.rocks'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     name: 🏷️ Validate PR title
     steps:
       - name: Validate PR title

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   stale-bugs:
     name: 🧹 Mark stale bug issues
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       issues: write # mark and close stale bug issues
     steps:
@@ -33,7 +33,7 @@ jobs:
 
   stale-prs:
     name: 🧹 Mark stale pull requests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write # mark and close stale pull requests
     steps:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ permissions: {}
 jobs:
   zizmor:
     name: 🌈 GitHub Actions security analysis
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read # checkout repository
 


### PR DESCRIPTION
## Summary
- Migrate CI/CD workflows off Blacksmith runners to GitHub-hosted runners
- `blacksmith-4vcpu-ubuntu-2404` / `blacksmith-8vcpu-ubuntu-2404` -> `ubuntu-latest`
- `blacksmith-4vcpu-ubuntu-2404-arm` / `blacksmith-8vcpu-ubuntu-2404-arm` -> `ubuntu-24.04-arm`

## Test plan
- [ ] CI passes on this PR with the new runner labels

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The validator was run against the parent and PR revisions to parse all changed workflow YAML files and verify every runner migration, and it showed that the parent revision reported 19 active Blacksmith labels and exited with status 1, while the PR revision exited with status 0 after validating 19 migrations, confirming ARM64 support for the Playwright container and finding no active Blacksmith labels.
- A separate git diff --check and an active-workflow residual-reference check were executed; both passed and confirmed that exactly nine workflow files changed with no residual Blacksmith references.

<a href="https://app.greptile.com/trex/runs/16918874/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: migrate from Blacksmith to GitHub-ho..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/304f878e68587b4490b157ad20c53bd48d62c1b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49386049)</sub>

<!-- /greptile_comment -->