### PR TITLE
chore(docs): update AGENTS.md to reflect recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,10 @@ pnpm vp run i18n:report          # Fail on missing/unused/dynamic i18n keys in a
 pnpm i18n:report:fix             # Remove unused keys from all locale feature files
 pnpm vp run i18n:schema          # Regenerate i18n/schemas/*.schema.json from en/*
 pnpm vp run build:lunaria        # Build Lunaria dashboard + status.json
+pnpm tolgee:push                 # Push extracted strings to Tolgee (project 33768)
+pnpm tolgee:pull                 # Pull translations from Tolgee and remap into i18n/locales/
+pnpm tolgee:ensure-languages     # Create any Tolgee project languages missing from .tolgeerc.cjs
+pnpm tolgee:extract              # Print strings the Tolgee CLI would extract (dry run)
 pnpm test                        # Run all Vitest projects
 pnpm test:unit                   # Run unit tests
 pnpm test:nuxt                   # Nuxt component/API tests


### PR DESCRIPTION
### 🔗 Linked issue

N/A — scheduled weekly maintenance routine that keeps `AGENTS.md` in sync with the codebase.

### 🧭 Context

Weekly review of PRs merged into `main` over the last 7 days (since the previous run's #324), looking for architecture, dependency, API/composable, Prisma, audit-logging, auth, test-utility, build/lint, component-pattern, view-transition, design-token, or dev-command changes that `AGENTS.md` doesn't yet reflect.

### 📚 Description

Reviewed PRs #313, #315, #322, #323, #325–#331, #334, #336–#338, #340–#343.

Most changes were infra/CI (Blacksmith ↔ Depot ↔ GitHub-hosted runner churn, later reverted/finalized in #343), i18n/Lunaria internals already covered by existing commands, or small UI/refactor fixes with no new pattern to document.

One gap found: #334 and #342 added Tolgee CLI integration (`.tolgeerc.cjs`, `scripts/tolgee-*.{ts,mjs}`) with four new `package.json` scripts — `tolgee:push`, `tolgee:pull`, `tolgee:ensure-languages`, `tolgee:extract` — that were never added to the Development Commands table. This PR adds them.

Everything else checked out already accurate (audit action registry, i18n commands, tsgolint opt-in lint task, etc.), so no other sections needed changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCxAwGY4KZKWnYdk19HvhP)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the initial contract-validation script to verify that AGENTS.md entries were absent before this change and to confirm the package-script mappings and the Tolgee project ID, while performing a real dry-run extraction without modifying files.
- Ran the REQUIRE\_DOCUMENTATION=1 contract-validation to verify that all four documented AGENTS.md entries are present, that tolgee extract prints keys, and that the extraction flow leaves the file tree unchanged and exits successfully.
- Compared the exact before and after validation steps described in AGENTS.md lines 89–92 and verified the documented Tolgee commands map to push, pull, language ensure, and extract in a non-mutating dry-run.

<a href="https://app.greptile.com/trex/runs/16990468/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(docs): update AGENTS.md to reflect..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/96a2a582a997d1fe1d5d7309da3adcce39317675) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49530885)</sub>

<!-- /greptile_comment -->