### PR TITLE
chore: remove stray commented-out watcher config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -311,7 +311,6 @@ export default defineNuxtConfig({
 		typescriptPlugin: true,
 		viteEnvironmentApi: !isStorybook,
 		typedPages: true,
-		// watcher: "builder", // TODO: remove this once the issue is fixed
 		checkOutdatedBuildInterval: 5 * 60 * 1000, // 5 minutes
 	},
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A — weekly redundant-comments audit.

### 🧭 Context

Scheduled routine review of comments touched by commits merged in the last 7 days. Most recent comments in the window are legitimate "why" explanations (e.g. the discord-api-types SSR interop notes, the i18n pull-remap rationale), but one leftover was flagged as clutter.

### 📚 Description

`nuxt.config.ts` had `watcher: "builder"` disabled by commenting it out in #338, left with `// TODO: remove this once the issue is fixed` — a TODO that doesn't reference any issue or explain what "the issue" is. Since there's no tracking reference to preserve, the dead line is removed outright rather than rewritten.

No other redundant, obvious, or outdated comments were found in files changed this week — two earlier PRs in the window (#340, #341) already cleaned up the other cases this routine would have flagged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPbDg8YzoqoPoZsJHNUepC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge: it removes inactive configuration text without changing evaluated Nuxt options or generated types.

No defects were found. Preparation and effective configuration comparison succeeded before and after the comment removal.

**Files Needing Attention:** None.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The authored validation script was executed to verify the T-Rex contract validation, and its outputs were captured as evidence.
- Both real preparation runs completed with Types generated in .nuxt.
- Configuration snapshots were byte-identical across runs, with experimental.watcher resolving to Nuxt's chokidar default and typedPages remaining true.
- No product files were modified during the validation.
- The authored validation script and its captured outputs were uploaded as evidence.

<a href="https://app.greptile.com/trex/runs/17220609/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove stray commented-out watche..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/161b3bf9d752451ef9e1802cd2f9dde58e676dd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50015885)</sub>

<!-- /greptile_comment -->