### PR TITLE
chore: remove redundant comments restating field names

### DIFF
--- a/lunaria.config.ts
+++ b/lunaria.config.ts
@@ -27,7 +27,6 @@ for (const l of currentLocales) {
 for (const baseLang of Object.keys(countryLocaleVariants)) {
 	if (baseLang === sourceLocale.lang) continue;
 	if (!localeSet.has(baseLang)) {
-		// Use the first variant's name or the base code as label
 		const variants = countryLocaleVariants[baseLang]!;
 		const label = variants[0]?.name ?? baseLang;
 		localeSet.add(baseLang);

--- a/shared/types/i18n-status.ts
+++ b/shared/types/i18n-status.ts
@@ -25,14 +25,11 @@ export interface I18nLocaleStatus {
 	label: string;
 	dir: Directions;
 	totalKeys: number;
-	/** Number of completed translations */
 	completedKeys: number;
 	/** List of missing key paths (dot notation) */
 	missingKeys: string[];
 	/** Completion percentage (0-100) */
 	percentComplete: number;
-	/** GitHub URL to edit this locale's translation file */
 	githubEditUrl: string;
-	/** GitHub URL to view history of this locale's translation file */
 	githubHistoryUrl: string;
 }


### PR DESCRIPTION
### 🔗 Linked issue

N/A — automated weekly comment-quality audit (no tracking issue).

### 🧭 Context

Scheduled routine that reviews comments added/modified in files touched over the last 7 days and flags ones that just restate the code instead of explaining *why*.

### 📚 Description

Scanned every comment added in commits from the last 7 days (`674572d..HEAD`) across `*.ts`/`*.vue` source files. Almost all of them already explain non-obvious rationale (workarounds, gotchas, invariants) and were left untouched. Two small spots restated the identifier with no added information:

- `shared/types/i18n-status.ts`: removed `/** Number of completed translations */`, `/** GitHub URL to edit this locale's translation file */`, and `/** GitHub URL to view history of this locale's translation file */` on `completedKeys`, `githubEditUrl`, and `githubHistoryUrl` — each comment was a verbatim restatement of the field name.
- `lunaria.config.ts`: removed `// Use the first variant's name or the base code as label` directly above `const label = variants[0]?.name ?? baseLang;`, which trivially restates the line beneath it.

No behavior changes — comment-only cleanup.

Note: this sandbox's network policy blocks `pkg.pr.new` (used by a pinned `@lunariajs/core` preview build in the lockfile), so `pnpm install`/`build`/`typecheck` could not be run here. The changes are comment-only deletions with no code or type impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzAV1W3iQqjPgkhKzaAuer)_

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification and found that its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove redundant comments restati..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/bcae7a5b053f6dbc148ea5c5383a45ca6a1929fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50390387)</sub>

<!-- /greptile_comment -->