### PR TITLE
ci(i18n): soft-fail Lunaria on newly tracked locale files

### DIFF
--- a/.github/workflows/lunaria.yml
+++ b/.github/workflows/lunaria.yml
@@ -34,4 +34,4 @@ jobs:
           sfw: true
 
       - name: Generate Lunaria Overview
-        uses: lunariajs/action@4911ad0736d1e3b20af4cb70f5079aea2327ed8e # astro-docs
+        uses: lunariajs/action@a0594f1c5b8d55fb367d8df607d5e2541c99e77d # v1-prerelease

--- a/lunaria.config.ts
+++ b/lunaria.config.ts
@@ -42,9 +42,12 @@ if (locales.length === 0) {
 // Build merge config from countryLocaleVariants:
 // Each variant locale merges keys from its base locale, so keys present in
 // the base file count as covered for the variant.
-// e.g. { 'en-US': ['en'], 'en-GB': ['en'], 'ar-EG': ['ar'], 'es-ES': ['es'], 'es-419': ['es'] }
+// e.g. { 'ar-EG': ['ar'], 'es-ES': ['es'], 'es-419': ['es'] }
 const merge: Merge = {};
 for (const [baseLang, variants] of Object.entries(countryLocaleVariants)) {
+	// Merging from the source locale is implicit via normal Lunaria tracking,
+	// and Lunaria cannot resolve the source locale as a `merge` entry.
+	if (baseLang === sourceLocale.lang) continue;
 	for (const variant of variants) {
 		// Each variant merges from its base language and (if not the source) implicitly
 		// from the source via normal Lunaria tracking.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pins `lunariajs/action` to the v1-prerelease soft-fail build and stops emitting Lunaria `merge` entries for the source locale (`en`).

## Why

`pull_request_target` runs the **base-branch** workflow. The current pin (`astro-docs` / `4911ad07`) hard-exits with `UncommittedFileFound` when a PR adds a new tracked locale file such as `i18n/locales/en/errors.json` (checkout is the base branch, so that file has no git history there).

That blocks PRs that introduce new i18n feature files — for example #355 — until this workflow pin lands on `main`.

The v1-prerelease build checks file existence first and soft-fails instead of crashing. It also actually implements `files.merge`, and cannot resolve the source locale as a merge entry, so `lunaria.config.ts` skips `en` → `en-*` merge entries (source merging is already implicit).

## Test plan

- [ ] Precursor PR's own Lunaria check stays green (no new locale files)
- [ ] After merge, re-run or push on #355 so Lunaria overview uses the soft-fail action and passes with `errors.json`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3df052ab-a849-4c2e-9585-8b59f44d3817?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3df052ab-a849-4c2e-9585-8b59f44d3817&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the installed Lunaria core prerelease against English, Spanish, es-ES, and es-419 dictionaries, with English remaining the source comparison dictionary and Spanish covering both regional variants.
- Compared the previous and pinned Lunaria action revisions on the same mocked pull\_request\_target base checkout lacking the English locale file; the previous revision exited with a failure and posted no overview, while the pinned revision exited successfully and posted one overview comment.
- Validated that Spanish inherited coverage while English remains the source dictionary, using the core inheritance harness to prove the alignment.
- Observed the before/after logs showing the missing-English locale scenario shifting from exit 1 with zero comments to exit 0 with one comment after the patch.

<a href="https://app.greptile.com/trex/runs/17416063/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(i18n): fix Lunaria overview crash on ..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/1cc2ec9d6afc762418c9a55da2e974a5a36cbd51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50401119)</sub>

<!-- /greptile_comment -->