### PR TITLE
ci(test): retry flaky Vitest browser component suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
       - name: 🌐 Install browser
         run: vp exec playwright install --with-deps chromium-headless-shell
 
+      - name: 🔼 Generate Prisma Client
+        run: vp run prisma:generate
+
       # Vitest browser-playwright occasionally drops the Chromium session mid-suite
       # (`Browser connection was closed` / `route.fulfill: Route is already handled!`)
       # after most or all assertions already passed. Retry the whole project so files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,23 @@ jobs:
       - name: 🌐 Install browser
         run: vp exec playwright install --with-deps chromium-headless-shell
 
+      # Vitest browser-playwright occasionally drops the Chromium session mid-suite
+      # (`Browser connection was closed` / `route.fulfill: Route is already handled!`)
+      # after most or all assertions already passed. Retry the whole project so files
+      # interrupted by the provider flake still run.
       - name: 🧪 Component tests
-        run: vp test --project nuxt --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml
+        run: |
+          set -euo pipefail
+          max_attempts=2
+          attempt=1
+          until vp test --project nuxt --coverage --reporter=default --reporter=junit --outputFile=test-report.junit.xml; do
+            if [ "${attempt}" -ge "${max_attempts}" ]; then
+              exit 1
+            fi
+            echo "::warning::Component tests failed (attempt ${attempt}/${max_attempts}); retrying after Vitest browser flake"
+            attempt=$((attempt + 1))
+            sleep 5
+          done
         env:
           NODE_OPTIONS: --max-old-space-size=8192
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -581,6 +581,14 @@ export default defineConfig({
 			},
 			() =>
 				defineVitestProject({
+					resolve: {
+						alias: {
+							// Same stub as the unit project: nuxt browser coverage remaps
+							// uncovered server files and would otherwise fail to resolve the
+							// Prisma-generated client (not checked in).
+							"#server/database/generated/client": `${rootDir}/test/__stubs__/prisma-generated-client`,
+						},
+					},
 					test: {
 						browser: {
 							enabled: true,
@@ -624,6 +632,8 @@ export default defineConfig({
 		coverage: {
 			enabled: true,
 			include: ["{app,server,shared}/**/*.{ts,vue}"],
+			// Satori OG templates are not Vue SFCs Vitest's V8 remapper can parse.
+			exclude: ["app/components/OgImage/**"],
 			provider: "v8",
 		},
 	},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -581,14 +581,6 @@ export default defineConfig({
 			},
 			() =>
 				defineVitestProject({
-					resolve: {
-						alias: {
-							// Same stub as the unit project: nuxt browser coverage remaps
-							// uncovered server files and would otherwise fail to resolve the
-							// Prisma-generated client (not checked in).
-							"#server/database/generated/client": `${rootDir}/test/__stubs__/prisma-generated-client`,
-						},
-					},
 					test: {
 						browser: {
 							enabled: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🔗 Linked issue

Fixes failed CI on `6c6b62f` ([run 31012531068](https://github.com/wolfstar-project/wolfstar.rocks/actions/runs/31012531068)).

### 🧭 Context

The push CI for `ci(i18n): soft-fail Lunaria on newly tracked locale files (#360)` failed in **Component tests** only. The Lunaria change itself is unrelated — the same SHA’s PR CI passed.

Root cause is a recurring Vitest browser-playwright flake on `ubuntu-24.04-arm`:

- `Browser connection was closed while running tests` (often while loading `Footer.spec.ts`)
- or `route.fulfill: Route is already handled!`

Typical outcome: **492 tests passed**, but ~4 files never finish and Vitest exits 1 on the unhandled provider error.

### 📚 Description

- Retry the nuxt component-test job once when the suite fails (full re-run so interrupted files still execute).
- Run `prisma:generate` before component tests (same as typecheck/browser jobs) so coverage remapping can resolve the generated client.
- Exclude `app/components/OgImage/**` from V8 coverage (Satori templates are not parseable as Vue SFCs by the remapper).

### Tradeoffs

- A full suite retry adds wall-clock only on flake failure (second attempt).
- Does not fix the upstream Vitest browser-playwright race; it makes CI resilient to it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5dd2db3-81fc-40a6-9eee-c71e467ea353?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5dd2db3-81fc-40a6-9eee-c71e467ea353&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Initial retry harness setup completed to prepare for the retry tests.
- Ran the retry harness to exercise the workflow retry logic with controlled vp outcomes; the first-failure/second-success scenario returned 0, and the two-fail scenario returned 1, showing the job retried exactly once and still failed when retries were exhausted.
- Executed the Nuxt browser component coverage test for test/nuxt/components/BuildEnvironment.spec.ts; Nuxt initialized, V8 coverage enabled, all 8 assertions passed, and a coverage report was generated with no OG-image entries.
- Validated locale merge behavior and Lunaria build by modeling the prior loop, importing lunaria.config.ts, and confirming post-change Spanish merges remain while English variants are absent, with vp run build:lunaria exiting 0.
- The lunaria post-change behavior log confirms the final state and build status after applying lunaria.config.ts.

<a href="https://app.greptile.com/trex/runs/17442221/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(test): generate Prisma client before ..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/8b81e177879b8b810ead84d2b6bb14811f0cc977) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50450367)</sub>

<!-- /greptile_comment -->