### PR TITLE
ci(i18n): add scheduled Tolgee translation sync workflow

### DIFF
--- a/.github/workflows/tolgee-sync.yml
+++ b/.github/workflows/tolgee-sync.yml
@@ -1,0 +1,72 @@
+name: tolgee-sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every day at 02:00 UTC
+    - cron: "0 2 * * *"
+
+concurrency:
+  group: tolgee-sync
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  sync-translations:
+    name: 🌐 Sync translations from Tolgee
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read # checkout repository; the sync branch is pushed with WOLFSTAR_TOKEN
+
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          # The push step sets an authenticated remote from WOLFSTAR_TOKEN
+          persist-credentials: false
+
+      - name: Install pnpm and Node.js v24
+        uses: pnpm/setup@c9883cc79df532ad1a7b81bf9ab944ceb090d65c # v2.0.0
+        with:
+          runtime: node@24
+          cache: true
+          # Install is run explicitly below so it can skip lifecycle scripts
+          install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Pull translations from Tolgee
+        env:
+          TOLGEE_API_KEY: ${{ secrets.TOLGEE_API_KEY }}
+        # `pnpm tolgee:pull` runs the CLI (config: .tolgeerc.cjs) and then
+        # scripts/tolgee-pull-remap.ts, which remaps Tolgee language tags
+        # (cs, zh-Hans, …) onto the Nuxt locale directories under i18n/locales.
+        run: pnpm tolgee:pull
+
+      - name: Commit any changes and create a pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.WOLFSTAR_TOKEN }}
+        run: |
+          git add i18n/locales;
+          if git diff-index --quiet HEAD --; then
+            echo "No translation changes to commit, exiting with code 0"
+            exit 0;
+          else
+            git remote set-url origin "https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git";
+            # Commit as the account behind WOLFSTAR_TOKEN
+            git config --local user.name "wolfstarbot";
+            git config --local user.email "169603024+wolfstarbot@users.noreply.github.com";
+            # Reuse a single fixed branch so re-runs update the existing PR
+            # instead of spawning a new one each time.
+            git checkout -B i18n;
+            git commit -sam "chore(i18n): update translations from Tolgee";
+            git push --force --set-upstream origin i18n;
+            if [ "$(gh pr list --head i18n --state open --json number --jq 'length')" = "0" ]; then
+              gh pr create -t "chore(i18n): update translations from Tolgee" -b "*bleep bloop* I synced the translations from Tolgee" -B main -H i18n;
+            else
+              echo "An open PR for the i18n branch already exists, skipping PR creation";
+            fi
+          fi

--- a/.github/workflows/tolgee-sync.yml
+++ b/.github/workflows/tolgee-sync.yml
@@ -27,24 +27,22 @@ jobs:
           # The push step sets an authenticated remote from WOLFSTAR_TOKEN
           persist-credentials: false
 
-      - name: Install pnpm and Node.js v24
-        uses: pnpm/setup@c9883cc79df532ad1a7b81bf9ab944ceb090d65c # v2.0.0
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
-          runtime: node@24
+          node-version: lts/*
           cache: true
-          # Install is run explicitly below so it can skip lifecycle scripts
-          install: false
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+          sfw: true
+          # root only, no scripts
+          run-install: |
+            - args: ["--filter", ".", "--ignore-scripts"]
 
       - name: Pull translations from Tolgee
         env:
           TOLGEE_API_KEY: ${{ secrets.TOLGEE_API_KEY }}
-        # `pnpm tolgee:pull` runs the CLI (config: .tolgeerc.cjs) and then
+        # `tolgee:pull` runs the CLI (config: .tolgeerc.cjs) and then
         # scripts/tolgee-pull-remap.ts, which remaps Tolgee language tags
         # (cs, zh-Hans, …) onto the Nuxt locale directories under i18n/locales.
-        run: pnpm tolgee:pull
+        run: vp run tolgee:pull
 
       - name: Commit any changes and create a pull request
         env:


### PR DESCRIPTION
### 🔗 Linked issue

<!-- No open issue; this ports an existing workflow from the bot repository. -->

### 🧭 Context

The dashboard already has the full Tolgee tooling in place (`.tolgeerc.cjs`, `pnpm tolgee:pull`, `scripts/tolgee-pull-remap.ts`), but translations were only ever pulled by hand. The bot repository (`wolfstar-project/wolfstar`) has run a scheduled sync for a while, so this adds the same automation here instead of inventing a new one.

### 📚 Description

Adds `.github/workflows/tolgee-sync.yml`: a daily (02:00 UTC) + `workflow_dispatch` job that pulls translations from Tolgee and opens a PR when `i18n/locales/` changes.

It mirrors the workflow in `wolfstar-project/wolfstar`, taking the version that already includes the duplicate-PR fix from wolfstar-project/wolfstar#238:

- the sync reuses a single force-pushed `i18n` branch instead of a new branch per run;
- before `gh pr create` it checks `gh pr list --head i18n --state open`, so a run with an open sync PR updates that PR rather than opening another one.

Steps are otherwise the same as the bot repo: install dependencies, pull, detect changes with `git diff-index --quiet HEAD --`, and commit as `wolfstarbot` pushed through `WOLFSTAR_TOKEN`.

Three deliberate differences from the bot repo's copy:

- toolchain setup goes through `voidzero-dev/setup-vp` with the root-only, no-lifecycle-scripts install used by the other workflows here, and the pull runs as `vp run tolgee:pull`, rather than the bot repo's `pnpm/setup` + explicit `pnpm install`;
- commits `i18n/locales` instead of `src/languages`;
- actions are pinned by commit SHA and permissions are `permissions: {}` + `contents: read` on the job — this repo runs `zizmor` at the `pedantic` persona in CI, which the bot repo does not;
- checkout uses `persist-credentials: false` rather than passing the token to `actions/checkout`; the push step sets an authenticated remote from `WOLFSTAR_TOKEN` anyway, so behaviour is unchanged.

**Reviewer notes**

- Requires two repository secrets: `WOLFSTAR_TOKEN` (push + `gh pr create`) and `TOLGEE_API_KEY` (Tolgee project 33768). The workflow will fail on the first scheduled run if either is missing.
- Using `WOLFSTAR_TOKEN` rather than `GITHUB_TOKEN` for the push is intentional: PRs opened with the workflow token do not trigger `ci` / `autofix.ci`.
- No tests: this is a workflow file with no runnable unit surface. Verified with `zizmor --persona pedantic` (no findings) and `bash -n` on each `run` block. End-to-end behaviour can only be confirmed by dispatching the workflow twice once the secrets exist — the second run should update the existing `i18n` PR instead of creating a new one.

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge based on successful execution of the updated install, translation pull, locale remapping, branch update, and pull-request reuse paths.

The changed workflow behavior was exercised in clean checkouts and against a local Git remote without finding a functional regression.

**Files Needing Attention:** No files require changes.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated baseline dependency install and Tolgee pull in a clean checkout.
- Validated the changed vp path installs and runs Tolgee pull, mirroring the baseline results.
- Exercise commit, force-push, and existing pull request detection logic against a local remote, confirming i18n branch update and PR reuse behavior.
- Inspected and confirmed the setup-vp configuration is parsed from YAML and appended to the VP install invocation.

<a href="https://app.greptile.com/trex/runs/17612118/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(i18n): set up Tolgee sync through set..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/b10656c6a3f95d6d860a185fa581fb4306ad5930) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50790237)</sub>

<!-- /greptile_comment -->