### PR TITLE
fix(sentry): make error reporting safer

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -9,37 +9,40 @@ const {
 const EXPECTED_HTTP_STATUSES = new Set([400, 401, 403, 404, 409, 429]);
 
 /**
- * Matches only application-generated H3 errors (created via `createError()`),
- * mirroring h3's own `isError()` marker check. Upstream dependency failures
- * (e.g. ofetch `FetchError`s from the bot API) also carry a numeric
- * `status`/`statusCode` but must stay visible in Sentry.
+ * Matches only errors the application deliberately created via `createError()`.
+ * The `__h3_error__` constructor marker alone is not enough: h3 normalizes
+ * every foreign exception (e.g. ofetch `FetchError`s from the bot API) with
+ * `createError()` before invoking Nitro's error hooks, so those wrappers carry
+ * the marker too. h3 flags normalized wrappers with `unhandled: true`, while
+ * deliberate `createError()` throws keep the default `unhandled: false`, so
+ * upstream dependency failures stay visible in Sentry.
  */
 function isApplicationHttpError(exception: unknown): exception is { statusCode: unknown } {
-	return (
-		typeof exception === "object" &&
-		exception !== null &&
-		(exception.constructor as { __h3_error__?: boolean } | undefined)?.__h3_error__ === true
-	);
+	if (typeof exception !== "object" || exception === null) return false;
+	if ((exception.constructor as { __h3_error__?: boolean } | undefined)?.__h3_error__ !== true) return false;
+	return (exception as { unhandled?: unknown }).unhandled !== true;
 }
 
-function getHttpStatus(event: Sentry.ErrorEvent, hint: Sentry.EventHint): number | undefined {
-	const originalException = hint.originalException;
+/**
+ * Application-generated H3 errors always carry a numeric `statusCode`, so no
+ * fallback to `event.contexts.response` is needed. Relying on the outgoing
+ * response status would wrongly drop unexpected statusless exceptions captured
+ * late in a request (e.g. an unhandled rejection after a 404/429 response).
+ */
+function getApplicationHttpStatus(hint: Sentry.EventHint): number | undefined {
+	const exception = hint.originalException;
 
-	if (isApplicationHttpError(originalException)) {
-		const status = originalException.statusCode;
+	if (!isApplicationHttpError(exception)) return undefined;
 
-		if (typeof status === "number") return status;
-	}
-
-	const responseStatus = event.contexts?.response?.status_code;
-	return typeof responseStatus === "number" ? responseStatus : undefined;
+	const status = exception.statusCode;
+	return typeof status === "number" ? status : undefined;
 }
 
 if (sentry.dsn) {
 	Sentry.init({
 		dsn: sentry.dsn,
 		beforeSend(event, hint) {
-			const status = getHttpStatus(event, hint);
+			const status = getApplicationHttpStatus(hint);
 			return status !== undefined && EXPECTED_HTTP_STATUSES.has(status) ? null : event;
 		},
 		// Set tracesSampleRate to 1.0 to capture 100%

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -8,12 +8,25 @@ const {
 
 const EXPECTED_HTTP_STATUSES = new Set([400, 401, 403, 404, 409, 429]);
 
+/**
+ * Matches only application-generated H3 errors (created via `createError()`),
+ * mirroring h3's own `isError()` marker check. Upstream dependency failures
+ * (e.g. ofetch `FetchError`s from the bot API) also carry a numeric
+ * `status`/`statusCode` but must stay visible in Sentry.
+ */
+function isApplicationHttpError(exception: unknown): exception is { statusCode: unknown } {
+	return (
+		typeof exception === "object" &&
+		exception !== null &&
+		(exception.constructor as { __h3_error__?: boolean } | undefined)?.__h3_error__ === true
+	);
+}
+
 function getHttpStatus(event: Sentry.ErrorEvent, hint: Sentry.EventHint): number | undefined {
 	const originalException = hint.originalException;
 
-	if (originalException && typeof originalException === "object") {
-		const exception = originalException as Record<string, unknown>;
-		const status = exception.statusCode ?? exception.status;
+	if (isApplicationHttpError(originalException)) {
+		const status = originalException.statusCode;
 
 		if (typeof status === "number") return status;
 	}

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -6,7 +6,7 @@ const {
 	public: { sentry, environment },
 } = generateRuntimeConfig();
 
-const expectedHttpStatuses = new Set([400, 401, 403, 404, 409, 429]);
+const EXPECTED_HTTP_STATUSES = new Set([400, 401, 403, 404, 409, 429]);
 
 function getHttpStatus(event: Sentry.ErrorEvent, hint: Sentry.EventHint): number | undefined {
 	const originalException = hint.originalException;
@@ -27,7 +27,7 @@ if (sentry.dsn) {
 		dsn: sentry.dsn,
 		beforeSend(event, hint) {
 			const status = getHttpStatus(event, hint);
-			return status !== undefined && expectedHttpStatuses.has(status) ? null : event;
+			return status !== undefined && EXPECTED_HTTP_STATUSES.has(status) ? null : event;
 		},
 		// Set tracesSampleRate to 1.0 to capture 100%
 		// Of transactions for tracing.

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -6,9 +6,29 @@ const {
 	public: { sentry, environment },
 } = generateRuntimeConfig();
 
+const expectedHttpStatuses = new Set([400, 401, 403, 404, 409, 429]);
+
+function getHttpStatus(event: Sentry.ErrorEvent, hint: Sentry.EventHint): number | undefined {
+	const originalException = hint.originalException;
+
+	if (originalException && typeof originalException === "object") {
+		const exception = originalException as Record<string, unknown>;
+		const status = exception.statusCode ?? exception.status;
+
+		if (typeof status === "number") return status;
+	}
+
+	const responseStatus = event.contexts?.response?.status_code;
+	return typeof responseStatus === "number" ? responseStatus : undefined;
+}
+
 if (sentry.dsn) {
 	Sentry.init({
 		dsn: sentry.dsn,
+		beforeSend(event, hint) {
+			const status = getHttpStatus(event, hint);
+			return status !== undefined && expectedHttpStatuses.has(status) ? null : event;
+		},
 		// Set tracesSampleRate to 1.0 to capture 100%
 		// Of transactions for tracing.
 		// We recommend adjusting this value in production

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -19,7 +19,8 @@ const EXPECTED_HTTP_STATUSES = new Set([400, 401, 403, 404, 409, 429]);
  */
 function isApplicationHttpError(exception: unknown): exception is { statusCode: unknown } {
 	if (typeof exception !== "object" || exception === null) return false;
-	if ((exception.constructor as { __h3_error__?: boolean } | undefined)?.__h3_error__ !== true) return false;
+	if ((exception.constructor as { __h3_error__?: boolean } | undefined)?.__h3_error__ !== true)
+		return false;
 	return (exception as { unhandled?: unknown }).unhandled !== true;
 }
 


### PR DESCRIPTION
## Summary

Reduce Sentry noise while preserving actionable production failures.

## Changes

- Filter expected HTTP control-flow errors (`400`, `401`, `403`, `404`, `409`, `429`) in server-side Sentry `beforeSend`.
- Filter only errors the application deliberately created via `createError()`, detected by h3's `__h3_error__` marker plus `unhandled: false`; h3-normalized wrappers around upstream failures (e.g. ofetch `FetchError`s from the bot API) carry `unhandled: true` and keep reaching Sentry.
- No response-context fallback: statusless unexpected exceptions captured late in a request (e.g. after a 404/429 response) are never dropped.
- Keep unexpected exceptions and `5xx` failures fully visible.
- Leave tracing configuration unchanged.

## Context

Expected validation, authentication, authorization, not-found, conflict, and rate-limit responses should not inflate the actionable Sentry error stream.

## Test plan

- [ ] Expected 4xx control-flow responses do not create Sentry error events.
- [ ] Unexpected exceptions still reach Sentry.
- [ ] 5xx responses still reach Sentry.
- [ ] Existing tracing and metrics remain unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Server-side Sentry reporting now excludes deliberate expected client-error responses while retaining unexpected HTTP errors and normalized upstream failures. Runtime checks confirmed the filter drops the selected deliberate H3 statuses and preserves an unhandled normalized upstream exception.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The exercised Sentry filtering paths preserve unexpected and upstream errors while removing only the intended deliberate client-error reports.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Sentry beforeSend end-to-end harness for 735ce0de (exit 1) and the working-tree (exit 0); the pre-change run failed as expected while the post-change run passed the end-to-end checks.
- The harness showed that 400, 401, 403, 404, 409, and 429 errors are filtered, while a deliberate 418 and the normalized upstream exception remain reportable.
- Ran the exact commands for pre-change and post-change validation and confirmed all eight focused assertions passed, including preservation of the normalized foreign exception.
- Artifacts including the focused harness source and the before/after logs were prepared for reviewer inspection.

<a href="https://app.greptile.com/trex/runs/17950466/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/wolfstar-project/wolfstar.rocks/commit/bdee2787697b2ce39d4e4a8534df133570f45a16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51466954)</sub>

<!-- /greptile_comment -->