### PR TITLE
fix(i18n): generate Lunaria before Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,9 @@
 #  https://docs.netlify.com/configure-builds/file-based-configuration/
 
 [build]
-command = "pnpm prisma:generate && pnpm vp run build:lunaria && pnpm run build" # build command
+# Lunaria failures only block production/canary deploys (CONTEXT=production, non-PR);
+# previews continue and modules/lunaria.ts retries with its preview-tolerant handling.
+command = "pnpm prisma:generate && (pnpm vp run build:lunaria || [ \"$PULL_REQUEST\" = \"true\" ] || [ \"$CONTEXT\" != \"production\" ]) && pnpm run build" # build command
 publish = "dist" # where the built project lives
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 #  https://docs.netlify.com/configure-builds/file-based-configuration/
 
 [build]
-command = "pnpm prisma:generate && pnpm run build" # build command
+command = "pnpm prisma:generate && pnpm run build:lunaria && pnpm run build" # build command
 publish = "dist" # where the built project lives
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 #  https://docs.netlify.com/configure-builds/file-based-configuration/
 
 [build]
-command = "pnpm prisma:generate && pnpm run build:lunaria && pnpm run build" # build command
+command = "pnpm prisma:generate && pnpm vp run build:lunaria && pnpm run build" # build command
 publish = "dist" # where the built project lives
 
 [build.environment]

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"audit:verify": "tsx scripts/audit-verify.ts",
 		"design:lint": "designmd lint .claude/DESIGN.md",
 		"build": "nuxt build",
+		"build:lunaria": "lunaria build",
 		"i18n:check:fix": "node scripts/compare-translations.ts --fix",
 		"i18n:report:fix": "node scripts/remove-unused-translations.ts",
 		"tolgee:push": "tolgee push",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
 		"audit:verify": "tsx scripts/audit-verify.ts",
 		"design:lint": "designmd lint .claude/DESIGN.md",
 		"build": "nuxt build",
-		"build:lunaria": "lunaria build",
 		"i18n:check:fix": "node scripts/compare-translations.ts --fix",
 		"i18n:report:fix": "node scripts/remove-unused-translations.ts",
 		"tolgee:push": "tolgee push",


### PR DESCRIPTION
## Summary

- run the existing vite-plus `build:lunaria` task after Prisma generation and before the Nuxt build on Netlify
- ensure `/translation-status` has the generated Lunaria artifact available during the production build

## Root cause

The Netlify pipeline currently runs `prisma:generate` followed directly by `nuxt build`. Lunaria is used by the translation-status page, but its build step is not part of the Netlify pipeline, so production can be built without the generated translation-status data.

```toml
[build]
command = "pnpm prisma:generate && pnpm vp run build:lunaria && pnpm run build"
```

The Lunaria build reuses the `build:lunaria` task already defined in `vite.config.ts` (which runs `node ./lunaria/lunaria.ts`). An earlier revision added a `build:lunaria` package.json script, but vite-plus rejects package scripts that shadow task-graph tasks (this broke every `vp run` invocation in CI), so the Netlify command invokes the vp task directly instead.

## Impact

Netlify now generates Lunaria data before Nuxt builds the application, keeping the production translation-status page aligned with the translation files in the deployed revision.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary
- Netlify now lets pull-request and preview deployments proceed to the application build when Lunaria generation is unavailable.
- Non-pull-request production deployments still stop before publishing when Lunaria generation fails.
- The previously reported preview error-handling bypass no longer occurs.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

No blocking failure remains. The deployment command was exercised with failing Lunaria generation across pull-request, preview, and production contexts; previews continued while non-pull-request production remained fail-closed.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured the exact current command tested: pnpm prisma:generate && (pnpm vp run build:lunaria || \[ '$PULL\_REQUEST' = 'true' \] || \[ '$CONTEXT' != 'production' \]) && pnpm run build.
- T-Rex compared this with the pre-capture parent command and observed that the earlier command sequence exited with code 1 and did not produce an app build.
- T-Rex observed that after capture, the preview/PR cases continue to run, while non-PR production still fails.
- T-Rex ran a Netlify harness syntax check to ensure the command harness is valid.

<a href="https://app.greptile.com/trex/runs/18014321/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(deploy): tolerate Lunaria failures o..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/ba3e5fd16f4cf44a058fefc6aaef5fcb917a98fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51605701)</sub>

<!-- /greptile_comment -->