### PR TITLE
chore(docs): update AGENTS.md to reflect recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,9 @@
 
 - Block order: template -> script -> script setup -> styles
 - Never create reactive state at module scope; use composables in `app/composables/`
-- Place feature-specific components in grouped directories once a feature has multiple pieces, e.g. feedback UI in `app/components/feedback/`
+- Place feature-specific components in grouped directories once a feature has multiple pieces, e.g. feedback UI in `app/components/feedback/`, OAuth status UI in `app/components/oauth/` (`StatusPanel.vue`, shared by all `app/pages/oauth/*.vue` for loading/success/error states)
 - In guild-settings `mapToGuildData()`/`calculateChanges()` functions, assign values onto `Partial<GuildData>` with `setGuildDataChange()` from `#shared/utils/guild-settings-map` instead of an `as any`/`as never` cast — it skips `undefined` so untouched keys stay out of PATCH payloads while keeping key/value types checked
+- Fatal errors render through `app/error.vue` → `app/components/ErrorPage.vue` (built on Nuxt UI's `UError`), with copy sourced from a dedicated `errors` i18n feature file (not `common`/`components`). Because `error.vue` replaces the app root on fatal errors, it must `await loadLocaleMessages(locale.value)` itself before translating — the normal per-route locale preloading doesn't run
 
 ## Auth and Feedback
 
@@ -196,6 +197,8 @@ Commit messages must follow Conventional Commits: `<type>(<scope>): <subject>`
 - **Hot reload broken:** Check file watcher limits on Linux, restart dev server
 - **Type errors after updates:** Run `pnpm nuxt prepare && pnpm prisma:generate`
 - **Duplicate/incompatible `vue`, `discord-api-types`, or `@unhead/vue`/`unhead` types after a dependency update:** Check the `overrides` in `pnpm-workspace.yaml` still pin a single version of each — two copies make structurally identical (nominally-branded) types incompatible during typecheck
+- **SSR crash reading a `discord-api-types` enum member (e.g. `Cannot read properties of undefined (reading 'VerifiedBot')`):** Vite SSR prebundling can produce a broken CJS interop stub of `discord-api-types/v10` where named enum exports are `undefined`. `vite.ssr.external: ["discord-api-types"]` in `nuxt.config.ts` keeps it external for Node/SSR; the client optimizer still prebundles `discord-api-types/v10` via `vite.optimizeDeps.include` (excluding it there breaks browser-mode Vitest). Module-scope code that reads enum members (e.g. marketing fixtures in `app/utils/constants.ts`) should inline the numeric values instead of importing the enum, so it's safe under either bundling path
+- **`pnpm typecheck` reports unfamiliar diagnostics or behaves differently from stock `tsc`:** `pnpm-workspace.yaml` overrides `typescript` to `typescript-native-bridge` (the `tsgo` native-compiler bridge) — this is an intentional adoption for faster typechecking, not a stray pin, but diagnostic wording/coverage can differ subtly from stock `tsc`
 
 **When in doubt:** Copy existing patterns from similar files (e.g., `server/api/guilds/**`, `app/components/discord/**`) before inventing new ones.
 
@@ -204,6 +207,7 @@ Commit messages must follow Conventional Commits: `<type>(<scope>): <subject>`
 - Client source maps are hidden via `sourcemap.client: "hidden"` and uploaded to Sentry through `@sentry/nuxt`.
 - Keep `sentry.sourcemaps.filesToDeleteAfterUpload` in `nuxt.config.ts` whenever changing source-map or build-output behavior so uploaded `.map` files are removed from `.output/**/public` and hidden deploy output directories.
 - Sentry runtime configuration lives in `sentry.client.config.ts`, `sentry.server.config.ts`, and `server/utils/runtimeConfig.ts`; keep DSNs and sampling in runtime config, not hardcoded values.
+- `sentry.server.config.ts`'s `Sentry.init` `beforeSend` drops events for expected `createError()` HTTP statuses (400/401/403/404/409/429). It distinguishes deliberate application errors from h3-normalized upstream failures (e.g. an ofetch `FetchError` from the bot API) via h3's `unhandled` flag on the `__h3_error__`-marked exception — only `unhandled: false` (deliberate) errors are filtered, so unexpected upstream failures still reach Sentry.
 
 ## Audit Logging
 


### PR DESCRIPTION
### 🔗 Linked issue

None — routine weekly AGENTS.md maintenance (scheduled task).

### 🧭 Context

This is the weekly automated review of PRs merged into `main` over the last 7 days (since #347, the previous AGENTS.md sync), checking whether new patterns introduced in that window are reflected in `AGENTS.md` (symlinked from `CLAUDE.md`).

### 📚 Description

Reviewed all PRs merged since #347 (#348–#372). Most were dependency bumps, CI tweaks, or narrow bug fixes that don't establish a new pattern; #369 had already updated `AGENTS.md` itself as part of its i18n fix. The following did introduce patterns worth documenting:

- **#333** (`feat(oauth): centered loading and success status panels`) — added `app/components/oauth/StatusPanel.vue`, a second example of the existing "grouped feature-component directory" convention (previously only `app/components/feedback/` was cited).
- **#355** (`feat(ui): add custom ErrorPage component replacing base UError`) — added `app/components/ErrorPage.vue` (wraps Nuxt UI's `UError`) rendered from `app/error.vue`, with a dedicated `errors` i18n feature file. Documented that `error.vue` must explicitly `await loadLocaleMessages()` since it replaces the app root and skips normal per-route locale preloading.
- **#371** (`fix(sentry): make error reporting safer`) — added a `beforeSend` filter in `sentry.server.config.ts` that drops expected `createError()` HTTP statuses while still reporting h3-normalized upstream failures (distinguished via the `unhandled` flag). Added to the Sentry section.
- **#349** (`fix: stabilize Nuxt SSR against discord-api-types interop`) — externalized `discord-api-types` for Vite SSR (`vite.ssr.external`) to work around a broken CJS interop stub that made enum named exports `undefined` during SSR. Added as a new Troubleshooting entry so a future SSR crash on a `discord-api-types` enum member points here instead of being re-debugged from scratch.
- **#335** (`chore: adopt typescript-native-bridge`) — `pnpm-workspace.yaml` now overrides `typescript` to `typescript-native-bridge` (tsgo). Added a Troubleshooting entry noting this is intentional, since it explains otherwise-unfamiliar `pnpm typecheck` diagnostics.

Checked and found no drift in: audit action creators (`shared/audit/actions.ts` still matches the documented table exactly), `package.json` dev commands (no new scripts added in this window), the design-token allow-list, and the view-transition system.

### Test plan

- [x] Docs-only change; no build/test impact
- [x] Diffed every relevant merged PR (#333, #335, #344, #346, #348, #349, #350, #351, #353, #355, #356, #357, #358, #360, #361, #362, #363, #364, #369, #372) against the current `AGENTS.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkGjv1sPUF62CJ9ZKevBEo)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only update records contributor guidance for shared UI, localized fatal errors, build troubleshooting, and Sentry configuration.

The Sentry filter-scope concern was disproved by an executed behavior check. A deliberate h3 404 error was dropped, while an h3-marked unhandled upstream-style 404 and a plain evlog-style 404 were both sent. The documentation already limits the filtering statement to expected `createError()` statuses, so it accurately describes the implemented behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the documentation matches the Sentry filtering behavior it describes.

The only concern was tested directly with deliberate h3, normalized upstream, and plain application-error shapes, and the observed results match the stated `createError()` scope.

**Files Needing Attention:** No files require changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Sentry beforeSend contract-check against a deliberate createError 404, an h3-marked unhandled 404, and a plain evlog 404, and observed that the deliberate createError 404 was dropped while the other two were sent.
- Compared AGENTS.md:210 and the sentry.server.config.ts rules with runtime output, and confirmed the documented createError() scope is accurate, with only the deliberate h3 error dropped and no files modified.

<a href="https://app.greptile.com/trex/runs/18038767/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(docs): update AGENTS.md to reflect..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/a4055cabaaf702ea4a47ee3165650c81383d3cfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51657072)</sub>

<!-- /greptile_comment -->