### PR TITLE
fix(theme): keep colors coherent when JavaScript is disabled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,12 @@ Files added to `ALLOW_LIST` in the test are permanently exempt. Current exemptio
 - `app/components/OgImage/Page.takumi.vue` — Satori does not support `var()` references
 - `app/components/discord/*.vue` (message, embed, mention, role, reaction, scrollbar, the `chat-input-command/` autocomplete family, and the `app-launcher/` family) — Discord brand fidelity requires Discord brand colors; see `ALLOW_LIST` in the test for the exact, growing file list
 
+### Theme Selectors
+
+`@nuxtjs/color-mode` applies `data-theme` (and the matching class) from an inline script, so with JavaScript disabled the html element carries no theme at all. Theme-conditional CSS must therefore go through the `theme-light`/`theme-dark` custom variants declared in `app/assets/css/main.css` — `@variant theme-dark { … }`, never a bare `[data-theme="dark"] & { … }` — because those variants also resolve the attribute-less state from `prefers-color-scheme`. Tailwind's own `dark:` variant is redefined alongside them and must stay identical to `theme-dark`.
+
+Only one DaisyUI theme may declare `default: true` (`light`): two defaults both emit `:where(:root)`, so the last one silently wins wherever no `data-theme` is set. `dark` stays reachable through `prefersdark: true`. `test/unit/design-tokens/theme-fallback.test.ts` enforces all of the above.
+
 ### Token Reference
 
 Prefer these semantic classes before reaching for palette colors:

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -7,6 +7,62 @@
 
 @source "../../../content/**/*";
 
+/*
+ * Theme variants that also cover the "no theme attribute" state.
+ *
+ * @nuxtjs/color-mode applies `data-theme` (and the matching class) from an
+ * inline script, so with JavaScript disabled the html element carries no theme
+ * at all. Everything keyed on `[data-theme]` would then silently fall back to
+ * whatever the bare declarations happen to be, mixing light and dark values on
+ * the same page. These variants resolve that state from the system preference
+ * instead, which mirrors `colorMode.preference: "system"`.
+ *
+ * `prefers-color-scheme: light` also matches user agents with no preference, so
+ * light stays the effective default — the same fallback as
+ * `colorMode.fallback: "light"`.
+ */
+@custom-variant theme-light {
+	&:where([data-theme="light"], [data-theme="light"] *, .light, .light *) {
+		@slot;
+	}
+
+	@media (prefers-color-scheme: light) {
+		&:where(:root:not([data-theme]), :root:not([data-theme]) *) {
+			@slot;
+		}
+	}
+}
+
+@custom-variant theme-dark {
+	&:where([data-theme="dark"], [data-theme="dark"] *, .dark, .dark *) {
+		@slot;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		&:where(:root:not([data-theme]), :root:not([data-theme]) *) {
+			@slot;
+		}
+	}
+}
+
+/*
+ * Nuxt UI defines `dark` as a class-based variant. Custom variants cannot alias
+ * each other, so repeat the `theme-dark` rules under Tailwind's own name to keep
+ * `dark:` utilities in step with the tokens above when no theme attribute is
+ * present. Keep both variants identical.
+ */
+@custom-variant dark {
+	&:where([data-theme="dark"], [data-theme="dark"] *, .dark, .dark *) {
+		@slot;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		&:where(:root:not([data-theme]), :root:not([data-theme]) *) {
+			@slot;
+		}
+	}
+}
+
 @plugin "@tailwindcss/typography";
 @plugin "daisyui";
 
@@ -45,9 +101,16 @@
 	--noise: 0;
 }
 
+/*
+ * Not `default: true`: two default themes both emit `:where(:root)`, so the one
+ * declared last (dark) used to win for every element without a `data-theme`
+ * attribute — including the no-JavaScript render, where it collided with the
+ * light `--ui-*` values below. `prefersdark` keeps this theme as the
+ * `:root:not([data-theme])` fallback under a dark system preference.
+ */
 @plugin "daisyui/theme" {
 	name: "dark";
-	default: true;
+	default: false;
 	prefersdark: true;
 	color-scheme: "dark";
 	--color-base-100: oklch(25% 0.016 252);
@@ -198,31 +261,34 @@
 		--ui-container: var(--container-7xl);
 	}
 
-	[data-theme="dark"],
-	.dark {
-		--ui-text-dimmed: var(--color-neutral-500);
-		--ui-text-muted: var(--color-neutral-400);
-		--ui-text-toned: var(--color-neutral-300);
-		--ui-text: var(--color-neutral-200);
-		--ui-text-highlighted: var(--color-white);
-		--ui-text-inverted: var(--color-neutral-900);
+	/* Nested in :root so the variant can widen the selector to the dark theme
+	   attribute, the dark class, and the attribute-less system-preference state. */
+	:root {
+		@variant theme-dark {
+			--ui-text-dimmed: var(--color-neutral-500);
+			--ui-text-muted: var(--color-neutral-400);
+			--ui-text-toned: var(--color-neutral-300);
+			--ui-text: var(--color-neutral-200);
+			--ui-text-highlighted: var(--color-white);
+			--ui-text-inverted: var(--color-neutral-900);
 
-		--ui-bg: var(--color-base-300);
-		--ui-bg-muted: var(--color-neutral-800);
-		--ui-bg-elevated: var(--color-neutral-800);
-		--ui-bg-accented: var(--color-neutral-700);
-		--ui-bg-inverted: var(--color-white);
+			--ui-bg: var(--color-base-300);
+			--ui-bg-muted: var(--color-neutral-800);
+			--ui-bg-elevated: var(--color-neutral-800);
+			--ui-bg-accented: var(--color-neutral-700);
+			--ui-bg-inverted: var(--color-white);
 
-		--ui-border: var(--color-base-100);
-		--ui-border-muted: var(--color-base-200);
-		--ui-border-accented: var(--color-base-200);
-		--ui-border-inverted: var(--color-white);
+			--ui-border: var(--color-base-100);
+			--ui-border-muted: var(--color-base-200);
+			--ui-border-accented: var(--color-base-200);
+			--ui-border-inverted: var(--color-white);
 
-		/* Lightest/elevated surface for Discord message mockups */
-		--discord-surface: var(--color-base-100);
+			/* Lightest/elevated surface for Discord message mockups */
+			--discord-surface: var(--color-base-100);
 
-		--ui-radius: var(--radius-box);
-		--ui-container: var(--container-7xl);
+			--ui-radius: var(--radius-box);
+			--ui-container: var(--container-7xl);
+		}
 	}
 
 	[data-theme="midnight"],

--- a/app/assets/css/utilities.css
+++ b/app/assets/css/utilities.css
@@ -182,7 +182,7 @@
 	border-radius: var(--radius-box, 0.5rem);
 	background: oklch(50% 0 0 / 0.05);
 
-	[data-theme="dark"] & {
+	@variant theme-dark {
 		border-color: oklch(100% 0 0 / 0.08);
 		background: oklch(20% 0 0 / 0.3);
 	}
@@ -254,7 +254,7 @@
 	border-radius: var(--radius-box, 0.5rem);
 	background: oklch(30% 0.01 250 / 0.6);
 
-	[data-theme="light"] & {
+	@variant theme-light {
 		background: oklch(95% 0.01 250 / 0.6);
 	}
 }
@@ -265,7 +265,7 @@
 	border-radius: var(--radius-box, 0.5rem);
 	background: oklch(25% 0.016 252 / 0.8);
 
-	[data-theme="light"] & {
+	@variant theme-light {
 		box-shadow: 0 4px 30px oklch(0% 0 0 / 0.05);
 		border-color: oklch(0% 0 0 / 0.1);
 		background: oklch(98% 0 0 / 0.8);
@@ -278,7 +278,7 @@
 	border-radius: var(--radius-box, 0.5rem);
 	background: oklch(40% 0.008 250 / 0.4);
 
-	[data-theme="light"] & {
+	@variant theme-light {
 		background: oklch(90% 0.008 250 / 0.4);
 	}
 }
@@ -289,7 +289,7 @@
 	backdrop-filter: blur(16px);
 	-webkit-backdrop-filter: blur(16px);
 
-	[data-theme="light"] & {
+	@variant theme-light {
 		--ui-bg: oklch(98% 0 0 / 0.85);
 	}
 }
@@ -299,7 +299,7 @@
 	backdrop-filter: blur(16px) saturate(180%);
 	-webkit-backdrop-filter: blur(16px) saturate(180%);
 
-	[data-theme="dark"] & {
+	@variant theme-dark {
 		backdrop-filter: blur(20px) saturate(180%);
 		-webkit-backdrop-filter: blur(20px) saturate(180%);
 	}
@@ -316,7 +316,7 @@
 	box-shadow: 0 4px 30px oklch(0% 0 0 / 0.1);
 	border: 1px solid oklch(100% 0 0 / 0.15);
 
-	[data-theme="light"] & {
+	@variant theme-light {
 		box-shadow: 0 4px 30px oklch(0% 0 0 / 0.05);
 		border-color: oklch(0% 0 0 / 0.1);
 	}
@@ -380,8 +380,10 @@
 		box-shadow: 0 12px 40px oklch(0% 0 0 / 0.1);
 	}
 
-	[data-theme="dark"] &:hover {
-		box-shadow: 0 12px 40px oklch(0% 0 0 / 0.3);
+	@variant theme-dark {
+		&:hover {
+			box-shadow: 0 12px 40px oklch(0% 0 0 / 0.3);
+		}
 	}
 }
 

--- a/test/unit/design-tokens/theme-fallback.test.ts
+++ b/test/unit/design-tokens/theme-fallback.test.ts
@@ -1,0 +1,97 @@
+/**
+ * No-JavaScript Theme Fallback Guardrail
+ *
+ * @nuxtjs/color-mode applies `data-theme` (and the matching class) from an inline
+ * script, so with JavaScript disabled the html element carries no theme at all.
+ * Anything keyed on `[data-theme]` then falls back to whatever bare declarations
+ * happen to be in the stylesheet, which is how light and dark values ended up
+ * mixed on the same page (wolfstar-project/wolfstar.rocks#234).
+ *
+ * These checks keep that fallback coherent: a single DaisyUI default theme, and
+ * theme-conditional CSS expressed through the `theme-light`/`theme-dark` variants
+ * that also resolve the attribute-less state from `prefers-color-scheme`.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "../../..");
+
+const mainCss = readFileSync(join(ROOT, "app/assets/css/main.css"), "utf-8");
+const utilitiesCss = readFileSync(join(ROOT, "app/assets/css/utilities.css"), "utf-8");
+
+/** Body of a `@custom-variant <name> { ... }` block, matched by brace depth. */
+function readCustomVariant(source: string, name: string): string | undefined {
+	const start = source.indexOf(`@custom-variant ${name} {`);
+	if (start === -1) {
+		return undefined;
+	}
+
+	let depth = 0;
+	for (let i = source.indexOf("{", start); i < source.length; i++) {
+		if (source[i] === "{") {
+			depth++;
+		} else if (source[i] === "}") {
+			depth--;
+			if (depth === 0) {
+				return source.slice(start, i + 1);
+			}
+		}
+	}
+
+	return undefined;
+}
+
+describe("no-JavaScript theme fallback", () => {
+	it("declares exactly one DaisyUI default theme", () => {
+		// Two `default: true` themes both emit `:where(:root)`, so the last one wins
+		// for every element without a `data-theme` attribute — including the
+		// no-JavaScript render, where it contradicts the `:root` --ui-* values.
+		const defaults = [...mainCss.matchAll(/@plugin\s+"daisyui\/theme"\s*\{([^}]*)\}/g)].filter(
+			(match) => /\bdefault:\s*true\s*;/.test(match[1] ?? ""),
+		);
+
+		expect(defaults).toHaveLength(1);
+		expect(defaults[0]?.[1]).toMatch(/\bname:\s*"light"\s*;/);
+	});
+
+	it("keeps a dark theme reachable through prefers-color-scheme", () => {
+		const dark = mainCss.match(/@plugin\s+"daisyui\/theme"\s*\{[^}]*name:\s*"dark"[^}]*\}/);
+
+		expect(dark?.[0]).toMatch(/\bprefersdark:\s*true\s*;/);
+	});
+
+	for (const name of ["theme-light", "theme-dark", "dark"]) {
+		it(`the \`${name}\` variant resolves the attribute-less state from the system preference`, () => {
+			const variant = readCustomVariant(mainCss, name);
+
+			expect(variant, `@custom-variant ${name} is not declared in main.css`).toBeDefined();
+			expect(variant).toContain("prefers-color-scheme");
+			expect(variant).toContain(":root:not([data-theme])");
+		});
+	}
+
+	it("keeps the `dark` variant identical to `theme-dark`", () => {
+		// Custom variants cannot alias each other, so Tailwind's own `dark:` variant
+		// repeats the theme-dark rules and has to be kept in sync by hand.
+		const themeDark = readCustomVariant(mainCss, "theme-dark")?.replace("theme-dark", "dark");
+
+		expect(readCustomVariant(mainCss, "dark")).toBe(themeDark);
+	});
+
+	it("expresses theme-conditional utilities through the variants", () => {
+		// A bare `[data-theme="..."]` selector never matches without JavaScript, so
+		// theme-conditional declarations must go through the variants above.
+		const violations = utilitiesCss
+			.split("\n")
+			.map((line, index) => ({ line, number: index + 1 }))
+			.filter(({ line }) => /\[data-theme[\]=]/.test(line))
+			.map(
+				({ line, number }) =>
+					`app/assets/css/utilities.css:${number} — ${line.trim()} — use @variant theme-light/theme-dark instead.`,
+			);
+
+		expect(violations).toEqual([]);
+	});
+});


### PR DESCRIPTION
@nuxtjs/color-mode applies `data-theme` from an inline script, so with
JavaScript disabled the html element carries no theme at all. Both DaisyUI
themes declared `default: true` and both emit `:where(:root)`, so the dark
palette won there while the Nuxt UI `--ui-*` overrides and the
`[data-theme="light"]` utilities stayed light — black text on dark surfaces.

Light is now the only DaisyUI default, and theme-conditional CSS goes through
new `theme-light`/`theme-dark` variants that also resolve the attribute-less
state from `prefers-color-scheme`, matching `colorMode.preference: "system"`.
Tailwind's `dark:` variant is widened the same way so `dark:` utilities stay in
step with the tokens.

Verified in Chromium with `javaScriptEnabled: false`: the render now matches
the scripted one under both light and dark system preferences.

Closes #234

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017XQaPHTuzj42z4fx5SdBoQ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789284067&installation_model_id=425462&pr_number=374&repository=wolfstar-project%2Fwolfstar.rocks&return_to=https%3A%2F%2Fgithub.com%2Fwolfstar-project%2Fwolfstar.rocks%2Fpull%2F374&signature=fa867ba800283fa72b87481dcacd8cf0b4a85456926a3206e0349fc15d3861a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes the attribute-less, no-JavaScript experience follow the visitor’s system color preference while retaining explicit light and dark theme behavior.

The source-only guardrail concern was dropped after an executed browser check disproved the claimed failure: generated Tailwind/DaisyUI CSS was loaded in Chromium for explicit light and dark themes and for JavaScript-disabled, attribute-less pages under both system preferences. Each rendered case applied the expected theme variants and computed colors.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on rendered checks of explicit and no-JavaScript theme behavior.

The reported concern was exercised through compiled CSS in Chromium and the predicted broken behavior did not occur: explicit themes and attribute-less system-preference fallbacks produced the expected variant activation and colors.

**Files Needing Attention:** No files need follow-up changes. The rendered behavior of app/assets/css/main.css and the guardrails in test/unit/design-tokens/theme-fallback.test.ts were checked.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran unit tests for the theme fallback design tokens and all seven guardrail checks passed.
- Compiled the stylesheet with Tailwind and DaisyUI and loaded it in Chromium, then verified light and dark theme activations, including the script-free behavior, with the stylesheet size and computed colors matching expectations.
- Validated the script-free rendering path also produced correct light/dark outcomes and confirmed the compiled stylesheet remained 356,196 bytes with colors matching.

<a href="https://app.greptile.com/trex/runs/18853790/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(theme): keep colors coherent when Ja..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/4d9469c4c7a824ae68faaf63e750db4a7cf45b67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53265241)</sub>

<!-- /greptile_comment -->