### PR TITLE
chore(renovate): pin shared preset to published ref so Renovate can resolve config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,39 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"prCreation": "immediate",
-	"extends": ["github>danielroe/renovate"]
+	"extends": ["github>wolfstar-project/.github:wolfstar-renovate#chore/shared-renovate-preset"],
+	"packageRules": [
+		{
+			"groupName": "vite dependencies",
+			"groupSlug": "vite",
+			"matchPackageNames": ["vite", "/^@vitejs//", "/^vite-/"]
+		},
+		{
+			"extends": ["packages:test"],
+			"matchPackageNames": ["c8", "happy-dom", "jsdom", "/vitest/", "/^@vitest//"],
+			"groupName": "test packages"
+		},
+		{
+			"extends": ["packages:linters"],
+			"matchPackageNames": ["commitlint", "knip", "publint"],
+			"groupName": "all linters"
+		},
+		{
+			"groupName": "nuxt core",
+			"groupSlug": "nuxt",
+			"matchPackageNames": [
+				"@nuxt/cli",
+				"@nuxt/kit",
+				"@nuxt/module-builder",
+				"@nuxt/schema",
+				"@nuxt/test-utils",
+				"@nuxt/vite-builder",
+				"@nuxt/webpack-builder",
+				"nuxi",
+				"nuxt",
+				"vue"
+			],
+			"schedule": ["at any time"]
+		}
+	]
 }


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789386635&installation_model_id=425462&pr_number=376&repository=wolfstar-project%2Fwolfstar.rocks&return_to=https%3A%2F%2Fgithub.com%2Fwolfstar-project%2Fwolfstar.rocks%2Fpull%2F376&signature=c2a9240c266752d5d3c43c3cb05791ba5de84053bc0700b57c053a865a330e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change replaces the external Renovate preset with WolfStar’s shared preset and adds grouping rules for Vite, test, lint, and Nuxt packages. The referenced shared-preset ref cannot be fetched: Renovate receives a 404 and rejects the configuration before dependency updates can be processed. Do not merge until `renovate.json` points to a published preset ref.

<h3>Confidence Score: 3/5</h3>

Not safe to merge because the new Renovate configuration fails to load and disables automated dependency updates.

A before-and-after Renovate dry run directly exercised preset resolution: the previous configuration completed, while the changed configuration failed after GitHub returned 404 for the configured ref.

**Files Needing Attention:** `renovate.json` needs its shared-preset reference replaced with an existing published immutable ref.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Authored base and head Renovate validation script to exercise the Renovate validation workflow.
- Captured the Base Renovate dry-run output with the prior preset to show how the validation behaves with the old configuration.
- Captured the Head Renovate dry-run output with the configured shared preset to verify the new validation path.
- Reviewed the second P1 finding and prepared validation notes; no artifacts were produced for this proof.
- Validated the general-contract: reproduced the Renovate validation, confirmed the live preset fetch returns 404 and the configuration is invalid, and described the exact validator that runs base/head dry-run checks.

<a href="https://app.greptile.com/trex/runs/19026953/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20wolfstar-project%2Fwolfstar.rocks%20PR%20%23376%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=wolfstar-project%2Fwolfstar.rocks&pr=376&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Arenovate.json%3A4%0A**Shared%20Renovate%20preset%20cannot%20resolve**%0A%0AThe%20ref%20pinned%20in%20%60extends%60%20does%20not%20exist%20in%20%60wolfstar-project%2F.github%60.%20Renovate%20receives%20a%20404%20for%20%60wolfstar-renovate.json%60%20at%20%60chore%2Fshared-renovate-preset%60%20and%20rejects%20the%20entire%20configuration%20before%20applying%20the%20local%20package%20rules.%20This%20stops%20dependency%20extraction%20and%20update%20pull%20requests%2C%20including%20automated%20security%20updates.%20Point%20this%20at%20a%20published%20immutable%20commit%20or%20tag%20containing%20the%20preset%2C%20or%20publish%20the%20preset%20at%20the%20configured%20ref.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=wolfstar-project%2Fwolfstar.rocks&pr=376&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Arenovate.json%3A4%0A**Shared%20Renovate%20preset%20cannot%20resolve**%0A%0AThe%20ref%20pinned%20in%20%60extends%60%20does%20not%20exist%20in%20%60wolfstar-project%2F.github%60.%20Renovate%20receives%20a%20404%20for%20%60wolfstar-renovate.json%60%20at%20%60chore%2Fshared-renovate-preset%60%20and%20rejects%20the%20entire%20configuration%20before%20applying%20the%20local%20package%20rules.%20This%20stops%20dependency%20extraction%20and%20update%20pull%20requests%2C%20including%20automated%20security%20updates.%20Point%20this%20at%20a%20published%20immutable%20commit%20or%20tag%20containing%20the%20preset%2C%20or%20publish%20the%20preset%20at%20the%20configured%20ref.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=376&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22wolfstar-project%2Fwolfstar.rocks%22%20on%20the%20existing%20branch%20%22claude%2Fslack-session-nqn02c%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fslack-session-nqn02c%22.%0A%0A%23%23%23%20Issue%201%0Arenovate.json%3A4%0A**Shared%20Renovate%20preset%20cannot%20resolve**%0A%0AThe%20ref%20pinned%20in%20%60extends%60%20does%20not%20exist%20in%20%60wolfstar-project%2F.github%60.%20Renovate%20receives%20a%20404%20for%20%60wolfstar-renovate.json%60%20at%20%60chore%2Fshared-renovate-preset%60%20and%20rejects%20the%20entire%20configuration%20before%20applying%20the%20local%20package%20rules.%20This%20stops%20dependency%20extraction%20and%20update%20pull%20requests%2C%20including%20automated%20security%20updates.%20Point%20this%20at%20a%20published%20immutable%20commit%20or%20tag%20containing%20the%20preset%2C%20or%20publish%20the%20preset%20at%20the%20configured%20ref.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.&repo=wolfstar-project%2Fwolfstar.rocks&uid=108079&ts=1786795081&sig=0d95e615e65324010f2b2856d6f0773e58faed236d7f18eb5de00c8416aa1d35&pr=376&platform=github&fid=06217371-3c90-4534-aa7e-60c67a170c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
renovate.json:4
**Shared Renovate preset cannot resolve**

The ref pinned in `extends` does not exist in `wolfstar-project/.github`. Renovate receives a 404 for `wolfstar-renovate.json` at `chore/shared-renovate-preset` and rejects the entire configuration before applying the local package rules. This stops dependency extraction and update pull requests, including automated security updates. Point this at a published immutable commit or tag containing the preset, or publish the preset at the configured ref.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(renovate): pin shared preset to pu..."](https://github.com/wolfstar-project/wolfstar.rocks/commit/181d29f4b56f120a43f9bf5f2e88db3b7119a028) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53604896)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->