### PR TITLE
chore(docs): update AGENTS.md to reflect recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,14 @@
 - Feedback UI uses the custom Sentry feedback flow under `app/components/feedback/`
 - Keep feedback validation in `shared/schemas/feedback.ts` so forms and submit handlers share the same Valibot schema
 
+## Settings and Preferences
+
+- Browser-local appearance/locale/motion preferences are consolidated behind `useSettings()` (`app/composables/useSettings.ts`), backed by a single `wolfstar-settings` localStorage key (`AppSettings`: `colorMode`, `reduceMotion`, `selectedLocale`). Its `useLocalStorage` ref is created once in a detached `effectScope`, not in the first caller's own setup scope, so persistence survives that caller unmounting
+- Prefer `useAppColorMode()`, `usePreferredLocale()`, and `useReduceMotion()` — thin wrappers around `useSettings()` — over reading/writing `wolfstar-settings` directly. `useAppColorMode()` also keeps `useColorMode().preference` in sync; `colorMode` supports `"system" | "light" | "dark" | "midnight"` (`midnight` is an experimental DaisyUI theme)
+- Legacy keys (`wolfstar-theme`, `user-prefers-locale`, `user-prefers-reduced-motion`) migrate into `wolfstar-settings` once, only when `wolfstar-settings` has never been persisted — that check must run before the storage ref is created, since `useLocalStorage` writes defaults synchronously on first read
+- `/profile` (aliased at `/account`) is not auth-gated: guests get a Settings tab (Appearance, Language, Accessibility) and a Discord sign-in CTA in place of the Servers tab, and guild data fetches skip `/api/users` when the user is anonymous
+- Theme and language controls live on `/profile`, not the footer
+
 ## Development Commands
 
 ```bash


### PR DESCRIPTION
### 🔗 Linked issue

N/A — routine weekly AGENTS.md maintenance.

### 🧭 Context

This is an automated weekly pass reviewing PRs merged into `main` over the last 7 days for gaps between the codebase and `AGENTS.md`, the instruction file AI coding agents rely on for this repo.

### 📚 Description

Reviewed 4 PRs merged since the last maintenance pass (`#373`):

- **#332 — `feat(ui): shared settings + guest /profile theme menu`**: consolidated `useReduceMotion`/`usePreferredLocale` (previously standalone composables) and a new `useAppColorMode` into a single `useSettings()` composable backed by one `wolfstar-settings` localStorage key, with legacy-key migration. `/profile` (aliased `/account`) is no longer auth-gated — guests get a Settings tab and a sign-in CTA in place of the Servers tab. Theme/language controls moved from the footer to `/profile`. **This was not yet documented as a standalone pattern**, so this PR adds a new "Settings and Preferences" section covering the composable API, the localStorage key/migration behavior, and the guest-accessible `/profile`.
- **#374 — `fix(theme): keep colors coherent when JavaScript is disabled`**: already updated `AGENTS.md` itself (the "Theme Selectors" subsection) as part of that PR — no further changes needed here.
- **#375 / #376 — Renovate config changes**: only touch `renovate.json`; no architecture, dependency, or pattern changes relevant to `AGENTS.md`.

### ✅ Verification

- Diffed the new section against the actual `app/composables/useSettings.ts` source and `app/pages/profile.vue` to confirm composable names, storage keys, and guest-access behavior are accurate.
- No other sections required changes; existing content remains accurate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GQ3WFzNtU7FNhDR3m8pANE)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar.rocks/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789560271&installation_model_id=425462&pr_number=378&repository=wolfstar-project%2Fwolfstar.rocks&return_to=https%3A%2F%2Fgithub.com%2Fwolfstar-project%2Fwolfstar.rocks%2Fpull%2F378&signature=7d2ee63b268eb428fd5908143601985ee8629c04da2766c74fbc9e94a4b6d751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update AGENTS.md to document settings consolidation and profile route behavior
> Updates [AGENTS.md](https://github.com/wolfstar-project/wolfstar.rocks/pull/378/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) to reflect recent changes to settings and routing.
>
> - Documents the consolidation of appearance, locale, and motion preferences under `useSettings()`, backed by a single `wolfstar-settings` localStorage key and an `effectScope`-backed ref.
> - Adds guidance to use `useAppColorMode()`, `usePreferredLocale()`, and `useReduceMotion()` as wrappers around `useSettings()`, with `colorMode` supporting `"system"`, `"light"`, `"dark"`, and `"midnight"` values.
> - Documents one-time migration of legacy keys (`wolfstar-theme`, `user-prefers-locale`, `user-prefers-reduced-motion`) into `wolfstar-settings`, with a requirement to check for prior persistence before creating the storage ref.
> - Documents `/profile` (aliased `/account`) route behavior for guests vs. authenticated users, including skipping `/api/users` when anonymous.
> - Notes that theme and language controls now live on `/profile` rather than the footer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 583cd4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->