### PR TITLE
fix(auth): keep OAuth callback dynamic

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -252,6 +252,10 @@ export default defineNuxtConfig({
 			},
 		},
 		"/oauth/callback": {
+			// Discord returns through this route before the server middleware forwards
+			// the OAuth response to Better Auth. A prerendered copy bypasses that
+			// middleware and leaves the browser on the callback status page.
+			prerender: false,
 			robots: "nosnippet,notranslate,noimageindex,noarchive,max-snippet:-1,max-image-preview:none,max-video-preview:-1",
 		},
 		// Redirect-only OAuth entry point: its middleware immediately redirects to


### PR DESCRIPTION
### 🔗 Linked issue

#XXXX

### 🧭 Context

Discord returns OAuth responses through `/oauth/callback`, where server middleware forwards the request to Better Auth. The route was being prerendered, allowing Netlify to serve a static page and bypass the middleware. Users then saw the "Login Required" state after returning from Discord.

This change keeps the callback route dynamic so every provider response reaches the server middleware.

### 📚 Description

- Disable prerendering for `/oauth/callback` in the Nuxt route rules.
- Document why the OAuth callback must remain dynamic.

Validation:

- `pnpm build` passed with the production site URL configured.
- `pnpm lint:fix` passed with existing warnings only.
- `pnpm typecheck` passed.
- `pnpm test` passed 129 of 131 test files; two unrelated Chromium specs timed out under the full-suite load.
- The two timed-out specs passed when rerun in isolation: 2 files and 11 tests.
- The production output contains no prerendered `/oauth/callback` asset and the Nitro manifest records `prerender: false`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable prerendering for `/oauth/callback` route in `nuxt.config.ts`
> Sets `prerender: false` on the `/oauth/callback` route rule so the callback is handled at runtime instead of serving a prerendered page. This keeps the OAuth callback dynamic for runtime state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e690b3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->