### PR TITLE
fix(auth): prevent shared session rate-limit lockout

### DIFF
--- a/server/auth.config.ts
+++ b/server/auth.config.ts
@@ -49,6 +49,12 @@ export default defineServerAuth(() => ({
 	},
 	advanced: {
 		cookiePrefix: runtimeConfig.session.name,
+		ipAddress: {
+			// Netlify supplies a single, trusted client IP. Keep Cloudflare as a
+			// fallback for deployments where it is the application runtime rather
+			// than the CDN in front of Netlify.
+			ipAddressHeaders: ["x-nf-client-connection-ip", "cf-connecting-ip"],
+		},
 	},
 	secondaryStorage: authSecondaryStorage,
 	rateLimit: {
@@ -57,6 +63,10 @@ export default defineServerAuth(() => ({
 		max: 100,
 		storage: "secondary-storage",
 		customRules: {
+			// Session reads happen during hydration, callback recovery, and tab
+			// refreshes. They are cookie-bound and must not prevent a completed
+			// OAuth flow from loading its newly-created session.
+			"/get-session": false,
 			// OAuth sign-in initiation is the only unauthenticated entry point
 			// (Discord-only login, no email/password) worth a tighter window.
 			"/sign-in/social": { window: 10, max: 5 },


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #381.

### 🧭 Context

Production OAuth callbacks could still end on “Session Not Found” after the callback page was removed from prerendering. The underlying `/api/auth/get-session` request was returning `429`: Better Auth could not resolve the client IP behind Netlify/Cloudflare and placed every visitor in one shared `no-trusted-ip|get-session` rate-limit bucket.

This regression predates #298 and was introduced when the Better Auth rate limiter became persistent in #297.

### 📚 Description

- trust Netlify's `x-nf-client-connection-ip` header first, with `cf-connecting-ip` as a fallback for Cloudflare-runtime deployments
- disable rate limiting for the cookie-bound, high-frequency `/get-session` read so hydration and OAuth recovery cannot lock out all users
- preserve the global Better Auth limiter and the stricter `/sign-in/social` rule

Validation completed locally:

- `pnpm lint:fix`
- `pnpm typecheck`
- `pnpm test` (1,636 tests)
- `NUXT_PUBLIC_SITE_URL=https://wolfstar.rocks NODE_OPTIONS=--max-old-space-size=4096 pnpm build`

The `no-mistakes` review gate could not run because its configured Claude account has reached its monthly spend limit; it produced no findings before stopping.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent shared session rate-limit lockout by exempting `/get-session`
> - Configures `advanced.ipAddress` in [server/auth.config.ts](https://github.com/wolfstar-project/wolfstar.rocks/pull/383/files#diff-e9cfcd75693d57ec5f978b6d8818f1cc565323cecf00eb16d68076ed1b6d05ff) to read client IPs from `x-nf-client-connection-ip` and `cf-connecting-ip` headers.
> - Adds an explicit `false` rule for `/get-session` in `rateLimit.customRules` to exempt the path from rate limiting.
> - Risk: If `x-nf-client-connection-ip` or `cf-connecting-ip` headers are absent or spoofed, IP resolution and rate limit bucketing may be inaccurate. The `/get-session` endpoint is now fully unrestricted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0db2c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->